### PR TITLE
Improve crash logs by returning the stderr and error messages

### DIFF
--- a/src/model/kaniBinaryRunner.ts
+++ b/src/model/kaniBinaryRunner.ts
@@ -132,7 +132,7 @@ async function execLog(command: string): Promise<number> {
 			if (stderr) {
 				// stderr is an output stream that happens when there are no problems executing the kani command but kani itself throws an error due to (most likely)
 				// a rustc error or an unhandled kani error
-				vscode.window.showErrorMessage('Kani Executable Crashed due to an underlying rustc error ->\n' + stderr);
+				vscode.window.showErrorMessage(`Kani Executable Crashed due to an underlying rustc error ->\n ${stderr}`);
 				reject();
 			}
 			else if (error) {
@@ -141,7 +141,7 @@ async function execLog(command: string): Promise<number> {
 					resolve(1);
 				} else {
 					// Error is an object created by nodejs created when nodejs cannot execute the command
-					vscode.window.showErrorMessage(`Kani Extension could not execute command ${command} due to error ->\n` + error);
+					vscode.window.showErrorMessage(`Kani Extension could not execute command ${command} due to error ->\n ${error}`);
 					reject();
 				}
 			}

--- a/src/model/kaniBinaryRunner.ts
+++ b/src/model/kaniBinaryRunner.ts
@@ -129,16 +129,23 @@ async function catchOutput(command: string): Promise<number> {
 async function execLog(command: string): Promise<number> {
 	return new Promise((resolve, reject) => {
 		execAsync(command, (error, stdout, stderr) => {
-			if (error) {
+			if (stderr) {
+				// stderr is an output stream that happens when there are no problems executing the kani command but kani itself throws an error due to (most likely)
+				// a rustc error or an unhandled kani error
+				vscode.window.showErrorMessage('Kani Executable Crashed due to an underlying rustc error ->\n' + stderr);
+				reject();
+			}
+			else if (error) {
 				if (error.code === 1) {
 					// verification failed
-					// console.log("error code 1", stderr);
 					resolve(1);
 				} else {
-					vscode.window.showErrorMessage('Kani Executable Crashed');
+					// Error is an object created by nodejs created when nodejs cannot execute the command
+					vscode.window.showErrorMessage(`Kani Extension could not execute command ${command} due to error ->\n` + error);
 					reject();
 				}
-			} else {
+			}
+			 else {
 				// verification successful
 				resolve(0);
 			}


### PR DESCRIPTION
### Description of changes: 

The crash logs did not contain any of the underlying errors, this change improves upon that by returning the underlying crash error which can be inspected fully as text if needed. An example underlying crash is shown below after the change ->

<img width="1552" alt="Screen Shot 2023-01-11 at 3 52 20 PM" src="https://user-images.githubusercontent.com/91620234/211915288-a9dd8f96-df6a-4d4e-b1fc-133a2c8edfa5.png">


### Resolved issues:

Resolves [#12 ](https://github.com/model-checking/kani-vscode-extension/issues/12)

### Testing:

* How is this change tested? Regression

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
