### PR TITLE
Fix Kani Crashes for cases where there is an underlying import error

### DIFF
--- a/src/model/kaniBinaryRunner.ts
+++ b/src/model/kaniBinaryRunner.ts
@@ -19,6 +19,44 @@ const execAsync = exec;
  * @param args - arguments to Kani if provided
  * @returns verification status (i.e success or failure)
  */
+export async function runKaniHarnessInterface(
+	rsFile: string,
+	harnessName: string,
+	args?: number,
+): Promise<any> {
+	let harnessCommand = '';
+	if (args !== undefined || NaN) {
+		harnessCommand = `${KaniConstants.KaniExecutableName} ${rsFile} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
+	} else {
+		harnessCommand = `${KaniConstants.KaniExecutableName} ${rsFile} ${KaniArguments.harnessFlag} ${harnessName}`;
+	}
+	const kaniOutput = await catchOutput(harnessCommand);
+	if(kaniOutput == 2) {
+		const crateURI = getRootDir();
+		let harnessCommand = '';
+
+		if (args === undefined || NaN) {
+			harnessCommand = `cd ${crateURI} && ${KaniConstants.CargoKaniExecutableName} ${KaniArguments.harnessFlag} ${harnessName}`;
+		} else {
+			harnessCommand = `cd ${crateURI} && ${KaniConstants.CargoKaniExecutableName} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
+		}
+
+		// Cargo Kani Output
+		const kaniOutput: number = await catchOutput(harnessCommand, true);
+		return kaniOutput;
+	}
+	return kaniOutput;
+}
+
+
+/**
+ * Run Kani as a command line binary
+ *
+ * @param rsFile - Path to the file that is to be verified
+ * @param harnessName - name of the harness that is to be verified
+ * @param args - arguments to Kani if provided
+ * @returns verification status (i.e success or failure)
+ */
 export async function runKaniHarness(
 	rsFile: string,
 	harnessName: string,
@@ -30,7 +68,8 @@ export async function runKaniHarness(
 	} else {
 		harnessCommand = `${KaniConstants.KaniExecutableName} ${rsFile} ${KaniArguments.harnessFlag} ${harnessName}`;
 	}
-	console.log(harnessCommand);
+
+	// Kani Output
 	const kaniOutput = await catchOutput(harnessCommand);
 	return kaniOutput;
 }
@@ -57,7 +96,7 @@ export async function runCargoKaniTest(
 		harnessCommand = `cd ${crateURI} && ${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
 	}
 	if (failedCheck) {
-		const kaniOutput: KaniResponse = await captureFailedChecksForTests(harnessName, harnessCommand);
+		const kaniOutput: KaniResponse = await captureFailedChecksForProof(harnessName, harnessCommand);
 		return kaniOutput;
 	} else {
 		const kaniOutput: number = await catchOutput(harnessCommand);
@@ -110,7 +149,7 @@ export async function runCommandPure(command: string): Promise<void> {
 }
 
 // Run Kani and return the checks that failed as a lazy process
-async function captureFailedChecksForTests(
+async function captureFailedChecksForProof(
 	harnessName: string,
 	harnessCommand: string,
 ): Promise<KaniResponse> {
@@ -119,26 +158,39 @@ async function captureFailedChecksForTests(
 }
 
 // Run a command and capture the command line output into a string
-async function catchOutput(command: string): Promise<number> {
+async function catchOutput(command: string, cargoKaniMode: boolean = false): Promise<number> {
 	const process = await execLog(command);
 	// console.log(process);
 	return process;
 }
 
 // exectute the command as a command line argument
-async function execLog(command: string): Promise<number> {
+async function execLog(command: string, cargoKaniMode: boolean = false): Promise<number> {
 	return new Promise((resolve, reject) => {
 		execAsync(command, (error, stdout, stderr) => {
-			if (error) {
+			if(stderr && !stdout) {
+				if(cargoKaniMode) {
+					// stderr is an output stream that happens when there are no problems executing the kani command but kani itself throws an error due to (most likely)
+					// a rustc error or an unhandled kani error
+					vscode.window.showErrorMessage(`Kani Executable Crashed due to an underlying rustc error ->\n ${stderr}`);
+					reject();
+				}
+				else{
+					resolve(2)
+				}
+			}
+			else if (error) {
 				if (error.code === 1) {
 					// verification failed
 					// console.log("error code 1", stderr);
 					resolve(1);
 				} else {
-					vscode.window.showErrorMessage('Kani Executable Crashed');
+					// Error is an object created by nodejs created when nodejs cannot execute the command
+					vscode.window.showErrorMessage(`Kani Extension could not execute command ${command} due to error ->\n ${error}`);
 					reject();
 				}
-			} else {
+			}
+			else {
 				// verification successful
 				resolve(0);
 			}

--- a/src/test-tree/createTests.ts
+++ b/src/test-tree/createTests.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 import { MarkdownString, TestMessage, Uri } from 'vscode';
 
 import { KaniResponse } from '../constants';
-import { captureFailedChecks, runCargoKaniTest, runKaniHarness } from '../model/kaniBinaryRunner';
+import { captureFailedChecks, runCargoKaniTest, runKaniHarness, runKaniHarnessInterface } from '../model/kaniBinaryRunner';
 import { checkFileForProofs, parseRustfile } from '../ui/sourceCodeParser';
 import { getContentFromFilesystem } from '../utils';
 
@@ -275,10 +275,10 @@ export class TestCase {
 		if (vscode.workspace.workspaceFolders !== undefined) {
 			//TODO: Change this to running harness
 			if (args === undefined || NaN) {
-				const outputKani: number = await runKaniHarness(rsFile!, harness_name);
+				const outputKani: number = await runKaniHarnessInterface(rsFile!, harness_name);
 				return outputKani;
 			} else {
-				const outputKani: number = await runKaniHarness(rsFile!, harness_name, args);
+				const outputKani: number = await runKaniHarnessInterface(rsFile!, harness_name, args);
 				return outputKani;
 			}
 		}


### PR DESCRIPTION
### Description of changes: 

Some crates contain import errors which cause script Kani (or just Kani command) to crash which in turn causes the extension to crash. The crash shows no information about the crash too which can confuse the user. This PR addresses both of these issues by adding a backup proof runner (i.e cargo kani command) which is slower to run on each harness but covers more cases safely. 

Before  - 

![image](https://user-images.githubusercontent.com/91620234/211982896-b3219b8b-7bf5-4432-aaf0-1e82acf2a8ad.png)

After the change - 
<img width="1508" alt="Screen Shot 2023-01-11 at 11 50 18 PM" src="https://user-images.githubusercontent.com/91620234/211983097-412ddec3-88c2-47c8-bcd2-06e5ed24e7f6.png">

and

![image](https://user-images.githubusercontent.com/91620234/211983168-dee978d5-b23f-4888-8031-fd71b0055965.png)

### Resolved issues:

Resolves #9 and #12 

### Call-outs:

1. This fixes the crash by adding a backup proof runner but the entire process can be made more efficient. As of now, the proofs run slower than ideal.
2. The logs provide the compiler when the extension crashes but the information can be overwhelming and needs to parsed by the user to locate the source of the problem.
3. the report finding is still broken and slow for cases where cargo kani is used (instead of single kani). 

### Testing:

* How is this change tested? Regression and manual checking

* Is this a refactor change? yes

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
