### PR TITLE
Patch broken report finding

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ node_modules/**
 **/*.gen.ts
 dist/**
 types/*.d.ts
+.eslintrc.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
         node: true,
         mocha: true,
     },
-    plugins: ['@typescript-eslint', 'header', 'no-null', 'eslint-plugin-tsdoc'],
+    plugins: ['@typescript-eslint', 'header', 'no-null', 'eslint-plugin-tsdoc', 'prettier'],
     extends: [
         'eslint:recommended',
         'plugin:@typescript-eslint/eslint-recommended',
@@ -24,6 +24,7 @@ module.exports = {
         "tsdoc/syntax": "warn",
         'no-async-promise-executor': 'off',
         '@typescript-eslint/no-misused-promises': 'off',
+        '@typescript-eslint/typedef': 'warn',
         '@typescript-eslint/prefer-regexp-exec': 'off',
         'no-async-promise-executors': 'off',
         '@typescript-eslint/consistent-type-assertions': 'off',

--- a/src/ui/reportView/callReport.ts
+++ b/src/ui/reportView/callReport.ts
@@ -1,6 +1,5 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-import { assert } from 'console';
 import * as fs from 'fs';
 import * as path from 'path';
 import process = require('process');
@@ -126,6 +125,7 @@ async function findPath(dir: string, filename: string): Promise<string> {
  */
 async function runVisualizeCommand(command: string): Promise<visualizeOutput> {
 	try{
+		vscode.window.showWarningMessage("Generating viewer report");
 		const {stdout, stderr} = await execPromise(command);
 		const serveReportCommand = await parseReportOutput(stdout);
 		// console.error(`stderr: ${stderr}`);

--- a/src/ui/reportView/callReport.ts
+++ b/src/ui/reportView/callReport.ts
@@ -155,7 +155,7 @@ async function parseReportOutput(stdout: string): Promise<string> {
 	return '';
 }
 
-// 	Util function to find the path of the report from the harness name
+// Util function to find the path of the report from the harness name
 async function checkPathExists(serverCommand: string): Promise<boolean> {
 	// Kani returns a structured string, using that structure
 	// to find the filepath embedded in the command string

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,9 @@
 		"rootDir": "src",
 		"strict": true,   /* enable all strict type-checking options */
 		/* Additional Checks */
-		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+		"noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+		"noImplicitAny": true,
+		"strictPropertyInitialization": true,
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
 		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
 		"resolveJsonModule": true,


### PR DESCRIPTION
### Description of changes: 

The report generated by CBMC Viewer using the --visualize is stored in the target directory in the user's crate. For a given harness, the process of generating the report in the extension can be triggered by clicking on the "view report" link provided in the error UI (picture shown below shows the link). 

The process itself was fairly ad-hoc and relied on naively searching for all the paths in the target directory containing the given harness's name in their path. There were 2 sub processes, 1. run the visualize command and generate report, 2. run the python command that serves the report's html file on a server. These processes were async with each other.

This total process broke frequently for 3 reasons -

1. The path finding itself was fairly broken i.e there can be scenarios where there are multiple directories which contain the same harness name even within the target directory where CBMC viewer stores the generated report.
2. The process for generating the report was done locally through the user's terminal. While this has the advantage of continuously updating the user with the status of the process, it has the disadvantage that the process is entirely on the user's side, which meant it wasn't possible to chain this process with the server process.
3. The process for generating the report was async with the process for starting the server and displaying the report on the browser.

This fix addresses both of these issues by using Kani's output and relying on Kani's output to find the path for the report. Almost all the cases that broke frequently now display the report as expected.
 
<img width="1552" alt="Screen Shot 2023-01-20 at 7 45 37 PM" src="https://user-images.githubusercontent.com/91620234/213830583-e183333d-f3fe-4ab3-ae07-fbc7ec854770.png">
<img width="1440" alt="Screen Shot 2023-01-20 at 7 45 11 PM" src="https://user-images.githubusercontent.com/91620234/213830587-14ac005b-ffa4-4210-9068-e5c1cb337537.png">
why this change is necessary.

### Resolved issues:

Resolves #5

### Call-outs:

1. As explained above, the change removes the process being run on the terminal, which means the user can be left waiting for the process to end before being updated with more information. For now, a brief pop up window displays that the process is being run in the background. However, in a future update, this needs to be fixed by showing a progress window to the user.

2. The underlying output that is being parsed is not the most reliable output, and if this process is to be stabilized, an API from Kani's side for the file output needs to be provided.

### Testing:

* How is this change tested? Manual testing against multiple harness scenarios

* Is this a refactor change? Yes

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
