### PR TITLE
[Prototype] [Do not Merge] Add button for concrete playback

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import {
 	getWorkspaceTestPatterns,
 	testData,
 } from './test-tree/createTests';
+import { callConcretePlayback } from './ui/concrete-playback/concretePlayback';
 import { callViewerReport } from './ui/reportView/callReport';
 import { showInformationMessage } from './ui/showMessage';
 import { checkFileForProofs } from './ui/sourceCodeParser';
@@ -203,6 +204,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		},
 	);
 
+	// Register the run viewer report command
+	const runningConcretePlayback = vscode.commands.registerCommand(
+		'Kani.runConcretePlayback',
+		async (harnessArgs) => {
+			callConcretePlayback('Kani.runConcretePlayback', harnessArgs);
+		},
+	);
+
 	// Callback function to Find or create files, update test tree and present to user upon trigger
 	async function updateNodeForDocument(e: vscode.TextDocument): Promise<void> {
 		if (e.uri.scheme !== 'file') {
@@ -232,4 +241,5 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(runKani);
 	context.subscriptions.push(runcargoKani);
 	context.subscriptions.push(runningViewerReport);
+	context.subscriptions.push(runningConcretePlayback);
 }

--- a/src/model/kaniBinaryRunner.ts
+++ b/src/model/kaniBinaryRunner.ts
@@ -33,8 +33,7 @@ export async function runKaniHarnessInterface(
 	const kaniOutput = await catchOutput(harnessCommand);
 
 	// output = 2 indicates there is an underlying error , example import error from rustc. Before crashing the extension completely, we try running cargo kani over the harness
-	if(kaniOutput == 2) {
-
+	if (kaniOutput == 2) {
 		vscode.window.showWarningMessage(`Switching to cargo kani as proof runner due to Kani error`);
 
 		const crateURI = getRootDir();
@@ -52,7 +51,6 @@ export async function runKaniHarnessInterface(
 	}
 	return kaniOutput;
 }
-
 
 /**
  * Run Kani as a command line binary
@@ -130,7 +128,7 @@ export async function captureFailedChecks(
 		harnessCommand = `${KaniConstants.KaniExecutableName} ${rsFile} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
 	}
 	const kaniOutput = await createFailedDiffMessage(harnessCommand);
-	if(kaniOutput.failedProperty == "error") {
+	if (kaniOutput.failedProperty == 'error') {
 		const crateURI = getRootDir();
 		let harnessCommand = '';
 
@@ -141,8 +139,7 @@ export async function captureFailedChecks(
 		}
 		const kaniOutput = await createFailedDiffMessage(harnessCommand);
 		return kaniOutput;
-	}
-	else{
+	} else {
 		return kaniOutput;
 	}
 }
@@ -187,29 +184,30 @@ async function catchOutput(command: string, cargoKaniMode: boolean = false): Pro
 async function execLog(command: string, cargoKaniMode: boolean = false): Promise<number> {
 	return new Promise((resolve, reject) => {
 		execAsync(command, (error, stdout, stderr) => {
-			if(stderr && !stdout) {
-				if(cargoKaniMode) {
+			if (stderr && !stdout) {
+				if (cargoKaniMode) {
 					// stderr is an output stream that happens when there are no problems executing the kani command but kani itself throws an error due to (most likely)
 					// a rustc error or an unhandled kani error
-					vscode.window.showErrorMessage(`Kani Executable Crashed due to an underlying rustc error ->\n ${stderr}`);
+					vscode.window.showErrorMessage(
+						`Kani Executable Crashed due to an underlying rustc error ->\n ${stderr}`,
+					);
 					reject();
+				} else {
+					resolve(2);
 				}
-				else{
-					resolve(2)
-				}
-			}
-			else if (error) {
+			} else if (error) {
 				if (error.code === 1) {
 					// verification failed
 					// console.log("error code 1", stderr);
 					resolve(1);
 				} else {
 					// Error is an object created by nodejs created when nodejs cannot execute the command
-					vscode.window.showErrorMessage(`Kani Extension could not execute command ${command} due to error ->\n ${error}`);
+					vscode.window.showErrorMessage(
+						`Kani Extension could not execute command ${command} due to error ->\n ${error}`,
+					);
 					reject();
 				}
-			}
-			else {
+			} else {
 				// verification successful
 				resolve(0);
 			}
@@ -227,7 +225,7 @@ async function createFailedDiffMessage(command: string): Promise<KaniResponse> {
 			} else {
 				// Error Case
 				vscode.window.showWarningMessage('Kani Executable Crashed while parsing error message');
-				resolve({failedProperty: "error", failedMessages: "error"})
+				resolve({ failedProperty: 'error', failedMessages: 'error' });
 			}
 		});
 	});

--- a/src/ui/concrete-playback/concretePlayback.ts
+++ b/src/ui/concrete-playback/concretePlayback.ts
@@ -1,0 +1,71 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import process = require('process');
+
+import * as vscode from 'vscode';
+
+import { KaniArguments, KaniConstants } from '../../constants';
+import { checkCargoExist, getRootDir } from '../../utils';
+
+const { exec } = require('child_process');
+const { promisify } = require('util');
+const execPromise = promisify(exec);
+
+/**
+ * Call the visualize flag on the harness and render the html page
+ *
+ * @param commandURI - vscode command that is being executed
+ * @param harnessObj - metadata about the harness
+ */
+export async function callConcretePlayback(
+	commandURI: string,
+	harnessObj: { harnessName: string; harnessFile: string; harnessType: boolean },
+): Promise<void> {
+	let finalCommand: string = '';
+	const searchDir: string = '';
+
+	const platform: NodeJS.Platform = process.platform;
+	const harnessName: string = harnessObj.harnessName;
+	const harnessFile: string = harnessObj.harnessFile;
+	const harnessType: boolean = harnessObj.harnessType;
+
+	// Detect source file
+	const terminal = vscode.window.activeTerminal ?? vscode.window.createTerminal();
+
+	// Generate the final visualize command for the supported platforms
+	if (platform === 'darwin' || platform == 'linux') {
+		const responseObject: string = createCommand(commandURI, harnessFile, harnessName, harnessType);
+		const crateURI: string = getRootDir();
+		finalCommand = `cd ${crateURI} && ${responseObject}`;
+	}
+
+	// Wait for the the visualize command to finish generating the report
+	terminal.sendText(finalCommand);
+	terminal.show();
+}
+
+// Check if cargo toml exists and create corresponding kani command
+function createCommand(
+	commandURI: string,
+	harnessFile: string,
+	harnessName: string,
+	harnessType: boolean,
+): string {
+	// Check if cargo toml exists
+	const isCargo = checkCargoExist();
+	let finalCommand: string = '';
+
+	if (!isCargo) {
+		const command: string = commandURI === 'Kani.runConcretePlayback' ? 'kani' : 'cargo kani';
+		finalCommand = `${command} ${harnessFile} --harness ${harnessName} --enable-unstable --concrete-playback=inplace`;
+	} else {
+		if (harnessType) {
+			const command: string = commandURI === 'Kani.runConcretePlayback' ? 'kani' : 'cargo kani';
+			finalCommand = `${command} ${harnessFile} --harness ${harnessName} --enable-unstable --concrete-playback=inplace`;
+		} else {
+			finalCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName} --visualize`;
+		}
+	}
+
+	return finalCommand;
+}

--- a/src/ui/concrete-playback/concretePlayback.ts
+++ b/src/ui/concrete-playback/concretePlayback.ts
@@ -1,15 +1,11 @@
-import * as fs from 'fs';
-import * as path from 'path';
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 import process = require('process');
 
 import * as vscode from 'vscode';
 
 import { KaniArguments, KaniConstants } from '../../constants';
 import { checkCargoExist, getRootDir } from '../../utils';
-
-const { exec } = require('child_process');
-const { promisify } = require('util');
-const execPromise = promisify(exec);
 
 /**
  * Call the visualize flag on the harness and render the html page
@@ -34,7 +30,12 @@ export async function callConcretePlayback(
 
 	// Generate the final visualize command for the supported platforms
 	if (platform === 'darwin' || platform == 'linux') {
-		const responseObject: string = createCommand(commandURI, harnessFile, harnessName, harnessType);
+		const responseObject: string = createConcretePlaybackCommand(
+			commandURI,
+			harnessFile,
+			harnessName,
+			harnessType,
+		);
 		const crateURI: string = getRootDir();
 		finalCommand = `cd ${crateURI} && ${responseObject}`;
 	}
@@ -45,7 +46,7 @@ export async function callConcretePlayback(
 }
 
 // Check if cargo toml exists and create corresponding kani command
-function createCommand(
+function createConcretePlaybackCommand(
 	commandURI: string,
 	harnessFile: string,
 	harnessName: string,


### PR DESCRIPTION
### Description of changes: 

UX Prototype to add concrete playback to the Kani extension. The underlying feature is not stable and provides for a poor UI so this will be merged only after concrete playback is stabilized.

The Button -
<img width="1552" alt="Screen Shot 2023-01-31 at 6 56 17 PM" src="https://user-images.githubusercontent.com/91620234/215911854-f3a5f363-5e3a-4595-b0aa-99baece76045.png">


The unit test generated - 
<img width="1552" alt="Screen Shot 2023-01-31 at 6 57 09 PM" src="https://user-images.githubusercontent.com/91620234/215911912-ab1398f5-cd1a-463f-b55a-3e9e96a3fd79.png">


### Resolved issues:

Resolves #21 

### Call-outs:

1. This is code only for the button, not for the feature itself. 
2. The feature itself is not fully tested, tests will be added during merge
3. It does paste the unit test into the source code successfully using the "inplace" command line option for some cases, but not reliably.

### Testing:

* How is this change tested? Not tested

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
