### PR TITLE
Fix `View report` feature to work in local and remote environments

### DIFF
--- a/src/test-tree/createTests.ts
+++ b/src/test-tree/createTests.ts
@@ -340,7 +340,7 @@ class FailedCase extends TestCase {
 		const stageCommandUri = Uri.parse(
 			`command:Kani.runViewerReport?${encodeURIComponent(JSON.stringify(args))}`,
 		);
-		sample.appendMarkdown(`[View Report for ${this.harness_name}](${stageCommandUri})`);
+		sample.appendMarkdown(`[Generate report for ${this.harness_name}](${stageCommandUri})`);
 
 		return sample;
 	}

--- a/src/ui/reportView/callReport.ts
+++ b/src/ui/reportView/callReport.ts
@@ -74,7 +74,7 @@ export async function callViewerReport(
 }
 
 // Show an error depending on the code we received
-function showVisualizeError(output: visualizeOutput) {
+function showVisualizeError(output: visualizeOutput): void {
 	switch (output.statusCode) {
 		// Could not run the visualize command
 		case 1:
@@ -94,7 +94,7 @@ function showVisualizeError(output: visualizeOutput) {
 
 // Shows an option to open the report in a browser. The process depends on
 // whether the extension executes on a local or remote environment.
-async function showVisualizeOutput(terminal: vscode.Terminal, output: visualizeOutput) {
+async function showVisualizeOutput(terminal: vscode.Terminal, output: visualizeOutput): Promise<void> {
 	if (output.result?.isLocal) {
 		// Shows a message with a button. Clicking the button opens the report
 		// in a browser.
@@ -103,14 +103,14 @@ async function showVisualizeOutput(terminal: vscode.Terminal, output: visualizeO
 			'Open in Browser'
 		);
 		if (response == 'Open in Browser') {
-			const uriPath = vscode.Uri.file(output.result?.path!);
+			const uriPath = vscode.Uri.file(output.result?.path ?? '');
 			vscode.env.openExternal(uriPath);
 		}
 	} else {
 		// Sends a command to the terminal that will start an HTTP server.
 		// VSCode automatically detects this and shows a message that allows
 		// you to open the report in a browser.
-		terminal.sendText(output.result?.command!);
+		terminal.sendText(output.result?.command ?? '');
 		terminal.show();
 	}
 }

--- a/src/ui/reportView/callReport.ts
+++ b/src/ui/reportView/callReport.ts
@@ -18,9 +18,16 @@ interface htmlMetaData {
 	searchDir: string;
 }
 
+interface visualizeResult {
+	isLocal: boolean;
+	path?: string;
+	command?: string;
+}
+
 interface visualizeOutput {
 	statusCode: number;
-	serverCommand: string;
+	result?: visualizeResult;
+	error?: string;
 }
 
 /**
@@ -57,25 +64,55 @@ export async function callViewerReport(
 		searchDir = responseObject.searchDir;
 	}
 
-	// Wait for the the visualize command to finish generating the report
+	// Wait for the visualize command to finish generating the report
 	const processOutput: visualizeOutput = await runVisualizeCommand(finalCommand, harnessName);
-	if (processOutput.statusCode == 1) {
-		// Could not run the visualize command, throw an error
-		vscode.window.showErrorMessage(
-			`Could not generate report due to execution error -> ${processOutput.serverCommand}`,
-		);
-		return;
-	} else if (processOutput.statusCode == 2) {
-		// Could run the command, but the file generated could not be verified or was generated at wrong location
-		vscode.window.showErrorMessage(
-			`Could not verify report path, error from Kani -> ${processOutput.serverCommand}`,
-		);
+	if (processOutput.statusCode != 0) {
+		showVisualizeError(processOutput);
 		return;
 	}
+	showVisualizeOutput(terminal, processOutput);
+}
 
-	// Send the command to the user which asks them if they want to view the report on the browser
-	terminal.sendText(processOutput.serverCommand);
-	terminal.show();
+// Show an error depending on the code we received
+function showVisualizeError(output: visualizeOutput) {
+	switch (output.statusCode) {
+		// Could not run the visualize command
+		case 1:
+			vscode.window.showErrorMessage(
+				`Could not generate report due to execution error: ${output.error}`,
+			);
+			break;
+		// Could run the command, but the file generated could not be verified or was generated at wrong location
+		case 2:
+			vscode.window.showErrorMessage(
+				`Could not find path to the report file`,
+			);
+			break;
+	}
+	return;
+}
+
+// Shows an option to open the report in a browser. The process depends on
+// whether the extension executes on a local or remote environment.
+async function showVisualizeOutput(terminal: vscode.Terminal, output: visualizeOutput) {
+	if (output.result?.isLocal) {
+		// Shows a message with a button. Clicking the button opens the report
+		// in a browser.
+		const response = await vscode.window.showInformationMessage(
+			'Report has been generated',
+			'Open in Browser'
+		);
+		if (response == 'Open in Browser') {
+			const uriPath = vscode.Uri.file(output.result?.path!);
+			vscode.env.openExternal(uriPath);
+		}
+	} else {
+		// Sends a command to the terminal that will start an HTTP server.
+		// VSCode automatically detects this and shows a message that allows
+		// you to open the report in a browser.
+		terminal.sendText(output.result?.command!);
+		terminal.show();
+	}
 }
 
 // Check if cargo toml exists and create corresponding kani command
@@ -109,54 +146,64 @@ function createCommand(
 }
 
 /**
- * Run the visualize command to generate the report, parse the output to return the python server command and status
+ * Run the visualize command to generate the report, parse the output and return the result
  *
  * @param command - the cargo kani | kani command to run --visualize
- * @returns - A promise of the python command and the status code; Promise<visualizeOutput>
+ * @returns - the result of executing the visualize command and parsing the output
  */
 async function runVisualizeCommand(command: string, harnessName: string): Promise<visualizeOutput> {
 	try {
 		vscode.window.showInformationMessage(`Generating viewer report for ${harnessName}`);
 		const { stdout, stderr } = await execPromise(command);
-		const serveReportCommand: string = await parseReportOutput(stdout);
-		if (serveReportCommand === '') {
-			return { statusCode: 2, serverCommand: stderr };
+		const parseResult = await parseReportOutput(stdout);
+		if (parseResult === undefined) {
+			return { statusCode: 2, result: undefined };
 		}
 		console.error(`stderr: ${stderr}`);
 
-		return { statusCode: 0, serverCommand: serveReportCommand };
+		return { statusCode: 0, result: parseResult };
 	} catch (error) {
 		console.error(`exec error: ${error}`);
-		return { statusCode: 1, serverCommand: error as string };
+		return { statusCode: 1, result: undefined, error: error as string};
 	}
 }
 
 /**
- * Search for the python command contained in Kani's output and throw it onto the user's terminal
+ * Search for the path to the report printed in Kani's output, and detect if we are in a remote
+ * enviroment before returning the result.
  *
- * @param stdout - kani stdout output that contains the full python command to be run by the terminal
- * @returns - python command that looks like "python3 -m http.server --path path"
+ * @param stdout - Kani's standard output after running the visualize command
+ * @returns - undefined (error) or a result that indicates if the extension is executed on a local
+ *  or remote environment. The result includes a `path` (if local) or a `command` (if remote).
  */
-async function parseReportOutput(stdout: string): Promise<string> {
+async function parseReportOutput(stdout: string): Promise<visualizeResult | undefined> {
 	const kaniOutput: string = stdout;
 	const kaniOutputArray: string[] = kaniOutput.split('\n');
-	const searchString: string = 'python3';
+	const searchString: string = 'Report written to:';
 
 	for (const outputString of kaniOutputArray) {
-		if (outputString.includes(searchString)) {
-			const command: string = outputString.split(searchString)[1];
+		if (outputString.startsWith(searchString)) {
+			const reportPath: string = outputString.split(' ')[3]
 
-			// Check if the HTML path that is to be served to the user exists as expected
-			const filePathExists: boolean = await checkPathExists(command);
+			// Check if the path exists as expected
+			const filePathExists: boolean = await checkPathExists(reportPath);
 			if (!filePathExists) {
-				return '';
+				return undefined;
 			}
-			return searchString + command;
+
+			// Determine if the environment is remote
+			if (process.env.SSH_CONNECTION !== undefined) {
+				// Generate the command using the path to the directory
+				const reportDir = reportPath.replace("/index.html", "");
+				return { isLocal: false, command: 'python3 -m http.server --directory ' + reportDir };
+			} else {
+				return { isLocal: true, path: reportPath };
+			}
 		}
 	}
 
 	// No command found from Kani
-	return '';
+	return undefined;
 }
 
 // Util function to find the path of the report from the harness name


### PR DESCRIPTION
### Description of changes: 

Currently, the extension relies on a Python command that is printed in Kani's output to get the path to the report. However, this command is only printed if Kani is being executed in remote computer through SSH. Because of that, the "View report" feature doesn't work as expected in a local environment.

This PR fixes these issues by searching for the path in another string contained in Kani's output which is always printed. It goes further by detecting if the extension is being executed in a local or remote environment. In a local environment, it will show a window to open the report in a browser. In a remote one, it will do the same it was doing until now (i.e., run a command that start an HTTP server through terminal, which automatically shows a message to open it in a browser).

The window that opens the report in a browser (in a local environment):
![Screen Shot 2023-02-16 at 12 12 02](https://user-images.githubusercontent.com/73246657/219438518-664482d1-dfe5-4728-aadf-25f8dacff384.png)

### Resolved issues:

Resolves #35 

### Testing:

* How is this change tested? Manually on both local and remote environments.

* Is this a refactor change? No, but it also contains refactoring changes (for showing errors or results).

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
