### PR TITLE
Show warning when using `Generate report` feature

### DIFF
--- a/src/ui/reportView/callReport.ts
+++ b/src/ui/reportView/callReport.ts
@@ -12,6 +12,8 @@ import { checkCargoExist, getRootDir } from '../../utils';
 const { exec } = require('child_process');
 const { promisify } = require('util');
 const execPromise = promisify(exec);
+const warningMessage = `Report generation is an unstable feature.
+Coverage information has been disabled due recent issues involving incorrect results.`
 
 interface htmlMetaData {
 	finalCommand: string;
@@ -70,7 +72,7 @@ export async function callViewerReport(
 		showVisualizeError(processOutput);
 		return;
 	}
-	showreportMetadata(terminal, processOutput);
+	showReportMetadata(terminal, processOutput);
 }
 
 // Show an error depending on the code we received
@@ -94,7 +96,7 @@ function showVisualizeError(output: reportMetadata): void {
 
 // Shows an option to open the report in a browser. The process depends on
 // whether the extension executes on a local or remote environment.
-async function showreportMetadata(terminal: vscode.Terminal, output: reportMetadata): Promise<void> {
+async function showReportMetadata(terminal: vscode.Terminal, output: reportMetadata): Promise<void> {
 	if (output.result?.isLocal) {
 		// Shows a message with a button. Clicking the button opens the report
 		// in a browser.
@@ -129,15 +131,15 @@ function createCommand(
 
 	if (!isCargo) {
 		const command: string = commandURI === 'Kani.runViewerReport' ? 'kani' : 'cargo kani';
-		finalCommand = `${command} ${harnessFile} --harness ${harnessName} --visualize`;
+		finalCommand = `${command} ${harnessFile} --harness ${harnessName} --enable-unstable --visualize`;
 		searchDir = path.join(getRootDir());
 	} else {
 		if (harnessType) {
 			const command: string = commandURI === 'Kani.runViewerReport' ? 'cargo kani' : 'kani';
-			finalCommand = `${command} --harness ${harnessName} --visualize`;
+			finalCommand = `${command} --harness ${harnessName} --enable-unstable --visualize`;
 			searchDir = path.join(getRootDir(), 'target');
 		} else {
-			finalCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName} --visualize`;
+			finalCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName} --enable-unstable --visualize`;
 			searchDir = path.join(getRootDir(), 'target');
 		}
 	}
@@ -154,6 +156,7 @@ function createCommand(
 async function runVisualizeCommand(command: string, harnessName: string): Promise<reportMetadata> {
 	try {
 		vscode.window.showInformationMessage(`Generating viewer report for ${harnessName}`);
+		vscode.window.showWarningMessage(warningMessage);
 		const { stdout, stderr } = await execPromise(command);
 		const parseResult = await parseReportOutput(stdout);
 		if (parseResult === undefined) {


### PR DESCRIPTION
### Description of changes: 

This PR updates the `Generate report` feature so it works with the latest version of Kani (requires `--enable-unstable` for `--visualize`). It also shows a warning to inform the user about the recent changes:

![Screen Shot 2023-02-28 at 14 12 56](https://user-images.githubusercontent.com/73246657/221956377-00ff2629-4105-44b6-b96c-33527986cbe8.png)

### Resolved issues:

Resolves #31 

### Call-outs:

The warning only shows the collapsed version at first. The current warning message has been written this way so it leads the user to expanding the message if he's interested in coverage information.
<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Manually (local) with installed Kani 0.22.0.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
