### PR TITLE
Deprecate standalone kani, add support for cargo-kani for every call

### DIFF
--- a/src/model/kaniCommandCreate.ts
+++ b/src/model/kaniCommandCreate.ts
@@ -3,7 +3,6 @@
 import * as vscode from 'vscode';
 
 import { KaniArguments, KaniConstants, KaniResponse } from '../constants';
-import { getRootDir } from '../utils';
 import { createFailedDiffMessage, runKaniCommand } from './kaniRunner';
 
 /**
@@ -15,7 +14,6 @@ import { createFailedDiffMessage, runKaniCommand } from './kaniRunner';
  * @returns verification status (i.e success or failure)
  */
 export async function runKaniHarnessInterface(
-	rsFile: string,
 	harnessName: string,
 	args?: number,
 ): Promise<any> {
@@ -43,7 +41,6 @@ export async function runCargoKaniTest(
 	failedCheck?: boolean,
 	args?: number,
 ): Promise<any> {
-	const crateURI = getRootDir();
 	let harnessCommand = '';
 	if (args === undefined || NaN) {
 		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName}`;
@@ -69,7 +66,6 @@ export async function runCargoKaniTest(
  * @returns
  */
 export async function captureFailedChecks(
-	rsFile: string,
 	harnessName: string,
 	args?: number,
 ): Promise<KaniResponse> {

--- a/src/model/kaniCommandCreate.ts
+++ b/src/model/kaniCommandCreate.ts
@@ -30,30 +30,6 @@ export async function runKaniHarnessInterface(
 }
 
 /**
- * Run Kani as a command line binary
- *
- * @param rsFile - Path to the file that is to be verified
- * @param harnessName - name of the harness that is to be verified
- * @param args - arguments to Kani if provided
- * @returns verification status (i.e success or failure)
- */
-export async function runKaniHarness(
-	rsFile: string,
-	harnessName: string,
-	args?: number,
-): Promise<any> {
-	let harnessCommand = '';
-	if (args !== undefined || NaN) {
-		harnessCommand = `${KaniConstants.KaniExecutableName} ${rsFile} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
-	} else {
-		harnessCommand = `${KaniConstants.KaniExecutableName} ${rsFile} ${KaniArguments.harnessFlag} ${harnessName}`;
-	}
-	// Kani Output
-	const kaniOutput = await catchOutput(harnessCommand);
-	return kaniOutput;
-}
-
-/**
  * Run cargo Kani --tests as a command line binary for harness declared
  * under #[test]
  *
@@ -98,26 +74,14 @@ export async function captureFailedChecks(
 	args?: number,
 ): Promise<KaniResponse> {
 	let harnessCommand = '';
-	if (args === undefined) {
-		harnessCommand = `${KaniConstants.KaniExecutableName} ${rsFile} ${KaniArguments.harnessFlag} ${harnessName}`;
+
+	if (args === undefined || NaN) {
+		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.harnessFlag} ${harnessName}`;
 	} else {
-		harnessCommand = `${KaniConstants.KaniExecutableName} ${rsFile} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
+		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
 	}
 	const kaniOutput = await createFailedDiffMessage(harnessCommand);
-	if (kaniOutput.failedProperty == 'error') {
-		const crateURI = getRootDir();
-		let harnessCommand = '';
-
-		if (args === undefined || NaN) {
-			harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.harnessFlag} ${harnessName} --output-format terse`;
-		} else {
-			harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args} --output-format terse`;
-		}
-		const kaniOutput = await createFailedDiffMessage(harnessCommand);
-		return kaniOutput;
-	} else {
-		return kaniOutput;
-	}
+	return kaniOutput;
 }
 
 // Generic function to run a command (Kani | Cargo Kani)

--- a/src/model/kaniCommandCreate.ts
+++ b/src/model/kaniCommandCreate.ts
@@ -18,10 +18,10 @@ export async function runKaniHarnessInterface(
 	args?: number,
 ): Promise<any> {
 	let harnessCommand = '';
-	if (args !== undefined || NaN) {
-		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
-	} else {
+	if (args === undefined || isNaN(args)) {
 		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.harnessFlag} ${harnessName}`;
+	} else {
+		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
 	}
 	const kaniOutput = await catchOutput(harnessCommand);
 	return kaniOutput;
@@ -42,7 +42,7 @@ export async function runCargoKaniTest(
 	args?: number,
 ): Promise<any> {
 	let harnessCommand = '';
-	if (args === undefined || NaN) {
+	if (args === undefined || isNaN(args)) {
 		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName}`;
 	} else {
 		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
@@ -71,7 +71,7 @@ export async function captureFailedChecks(
 ): Promise<KaniResponse> {
 	let harnessCommand = '';
 
-	if (args === undefined || NaN) {
+	if (args === undefined || isNaN(args)) {
 		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.harnessFlag} ${harnessName}`;
 	} else {
 		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;

--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -62,20 +62,13 @@ export async function runKaniCommand(
 	// Get cargo command and args for the command to be executed
 	const command = commmandSplit.commandPath;
 	const args = commmandSplit.args;
-	let kaniBinaryPath = '';
+	const kaniBinaryPath = '';
 
 	if (command == 'cargo' || command == 'cargo kani') {
 		const kaniBinaryPath = await getKaniPath('cargo-kani');
 		const options = {
 			shell: false,
 			cwd: directory,
-		};
-
-		return executeKaniProcess(kaniBinaryPath, args, options, cargoKaniMode);
-	} else if (command == 'kani') {
-		kaniBinaryPath = await getKaniPath(command);
-		const options = {
-			shell: false,
 		};
 
 		return executeKaniProcess(kaniBinaryPath, args, options, cargoKaniMode);
@@ -104,20 +97,6 @@ export async function runKaniCommand(
 		const options = {
 			shell: false,
 			cwd: directory,
-		};
-
-		return new Promise((resolve, reject) => {
-			execFile(kaniBinaryPath, args, options, (error, stdout, stderr) => {
-				if (stdout) {
-					const responseObject: KaniResponse = responseParserInterface(stdout);
-					resolve(responseObject);
-				}
-			});
-		});
-	} else if (commmandSplit.commandPath == 'kani') {
-		const kaniBinaryPath = await getKaniPath('kani');
-		const options = {
-			shell: false,
 		};
 
 		return new Promise((resolve, reject) => {

--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -62,7 +62,6 @@ export async function runKaniCommand(
 	// Get cargo command and args for the command to be executed
 	const command = commmandSplit.commandPath;
 	const args = commmandSplit.args;
-	const kaniBinaryPath = '';
 
 	if (command == 'cargo' || command == 'cargo kani') {
 		const kaniBinaryPath = await getKaniPath('cargo-kani');
@@ -132,7 +131,6 @@ function executeKaniProcess(
 	cargoKaniMode: boolean,
 ): Promise<any> {
 	return new Promise((resolve, reject) => {
-		console.log(args);
 		execFile(kaniBinaryPath, args, options, (error, stdout, stderr) => {
 			if (stderr && !stdout) {
 				if (cargoKaniMode) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "ES2018",
+		"target": "ES2020",
 		"outDir": "out",
 		"lib": [
-			"ES2018"
+			"ES2020"
 		],
 		"sourceMap": true,
 		"rootDir": "src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "ES2020",
+		"target": "ES2018",
 		"outDir": "out",
 		"lib": [
-			"ES2020"
+			"ES2018"
 		],
 		"sourceMap": true,
 		"rootDir": "src",


### PR DESCRIPTION
### Description of changes: 

Switch to cargo-kani for all commands, and deprecate usage of standalone kani.


### Call-outs:

Need to raise an issue or call out in documentation that we don't support standalone kani as a proof runner i.e we require that the extension be run on a crate with a declared cargo.toml. This is similar to how rust-analyzer handles it too, https://github.com/rust-lang/rust-analyzer/issues/8818.  

### Testing:

* How is this change tested? Manual testing

* Is this a refactor change? Yes

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
