### PR TITLE
Replace regex parsing with tree sitter

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,1 @@
-{ "printWidth": 100, "singleQuote": true, "trailingComma": "all", "semi": true, "useTabs": true, "bracketSpacing": true, "tabWidth": 2 }
+{ "printWidth": 100, "singleQuote": true, "trailingComma": "all", "semi": true, "useTabs": true, "bracketSpacing": true, "tabWidth": 2, "proseWrap": "always" }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ import {
 } from './test-tree/createTests';
 import { callViewerReport } from './ui/reportView/callReport';
 import { showInformationMessage } from './ui/showMessage';
-import { checkFileForProofs } from './ui/sourceCodeParser';
+import { SourceCodeParser } from './ui/sourceCodeParser';
 import { startWatchingWorkspace } from './ui/watchWorkspace';
 import { checkCargoExist, getContentFromFilesystem, getRootDirURI } from './utils';
 
@@ -206,7 +206,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 			return;
 		}
 
-		if (!checkFileForProofs(await getContentFromFilesystem(e.uri))) {
+		if (!SourceCodeParser.checkFileForProofs(await getContentFromFilesystem(e.uri))) {
 			return;
 		}
 

--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -106,8 +106,8 @@ export async function runKaniCommand(
 			cwd: directory,
 		};
 
-		return new Promise((resolve, reject) => {
-			execFile(kaniBinaryPath, args, options, (error, stdout, stderr) => {
+		return new Promise((resolve, _reject) => {
+			execFile(kaniBinaryPath, args, options, (_error, stdout, _stderr) => {
 				if (stdout) {
 					const responseObject: KaniResponse = responseParserInterface(stdout);
 					resolve(responseObject);
@@ -120,8 +120,8 @@ export async function runKaniCommand(
 			shell: false,
 		};
 
-		return new Promise((resolve, reject) => {
-			execFile(kaniBinaryPath, args, options, (error, stdout, stderr) => {
+		return new Promise((resolve, _reject) => {
+			execFile(kaniBinaryPath, args, options, (_error, stdout, _stderr) => {
 				if (stdout) {
 					const responseObject: KaniResponse = responseParserInterface(stdout);
 					resolve(responseObject);
@@ -131,7 +131,7 @@ export async function runKaniCommand(
 	} else {
 		// Error Case
 		vscode.window.showWarningMessage('Kani executable crashed while parsing error message');
-		return new Promise((resolve, reject) => {
+		return new Promise((resolve, _reject) => {
 			resolve({ failedProperty: 'error', failedMessages: 'error' });
 		});
 	}

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 import * as path from 'path';
 
-import * as glob from 'glob';
-import * as Mocha from 'mocha';
+import glob = require('glob');
+import Mocha from 'mocha';
 
 export function run(): Promise<void> {
 	// Create the mocha test

--- a/src/test/test-programs/sampleRustString.ts
+++ b/src/test/test-programs/sampleRustString.ts
@@ -1,14 +1,14 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-export const programWithProof = `
+export const fullProgramSource= `
 #[cfg(test)]
 mod test {
     #[test]
     #[cfg_attr(kani, kani::proof, kani::unwind(0))]
     #[cfg_attr(miri, ignore)] // this test is too expensive for miri
-    fn insert_test() {
+    fn insert_test_80978342() {
         // Make sure the two packet numbers are not the same
-        assert!(1==2);
+        assert!(1==3);
     }
 
     #[test]
@@ -24,7 +24,7 @@ mod test {
     #[cfg_attr(miri, ignore)] // this test is too expensive for miri
     fn random_name() {
         // Make sure the two packet numbers are not the same
-        assert!(1==1);
+        assert!(1==2);
     }
 }
 
@@ -41,7 +41,95 @@ fn function_abc() {
 pub fn function_xyz() {
     assert!(1 == 2);
 }
+
+#[cfg(kani)]
+#[kani::proof]
+#[kani::unwind(2)]
+#[kani::solver(kissat)]
+unsafe fn function_xyz_2() {
+    assert!(1 == 2);
+}
+
+#[cfg(kani)]
+#[kani::proof]
+pub unsafe fn function_xyz_3() {
+    assert!(1 == 2);
+}
+
+#[cfg(kani)]
+#[kani::proof]
+#[kani::unwind(0)]
+#[kani::solver(kissat)]
+fn function_xyz_7() {
+    assert!(1 == 2);
+}
 `;
+
+export const boleroProofs = `
+#[cfg(test)]
+mod test {
+    #[test]
+    #[cfg_attr(kani, kani::proof, kani::unwind(0))]
+    #[cfg_attr(miri, ignore)] // this test is too expensive for miri
+    fn insert_test_80978342() {
+        // Make sure the two packet numbers are not the same
+        assert!(1==3);
+    }
+
+    #[test]
+    #[cfg_attr(kani, kani::proof, kani::unwind(1))]
+    #[cfg_attr(miri, ignore)] // this test is too expensive for miri
+    fn insert_test_2() {
+        // Make sure the two packet numbers are not the same
+        assert!(1==1);
+    }
+
+    #[test]
+    #[cfg_attr(kani, kani::proof, kani::unwind(1))]
+    #[cfg_attr(miri, ignore)] // this test is too expensive for miri
+    fn random_name() {
+        // Make sure the two packet numbers are not the same
+        assert!(1==2);
+    }
+}`;
+
+export const kaniProofs = `
+#[cfg(kani)]
+#[kani::proof]
+#[kani::unwind(0)]
+fn function_abc() {
+    assert!(1 == 2);
+}
+
+
+#[cfg(kani)]
+#[kani::proof]
+pub fn function_xyz() {
+    assert!(1 == 2);
+}
+
+#[cfg(kani)]
+#[kani::proof]
+#[kani::unwind(2)]
+#[kani::solver(kissat)]
+unsafe fn function_xyz_2() {
+    assert!(1 == 2);
+}
+
+#[cfg(kani)]
+#[kani::proof]
+pub unsafe fn function_xyz_3() {
+    assert!(1 == 2);
+}
+
+#[cfg(kani)]
+#[kani::proof]
+#[kani::unwind(0)]
+#[kani::solver(kissat)]
+fn function_xyz_7() {
+    assert!(1 == 2);
+}
+`
 
 export const rustFileWithoutProof = `
 #[cfg(test)]
@@ -68,3 +156,259 @@ mod test {
     }
 }
 `;
+
+
+export const findHarnessesResultKani = [
+    {
+      "name": "function_abc",
+      "fullLine": "fn function_abc() {",
+      "endPosition": {
+        "row": 4,
+        "column": 15
+      },
+      "attributes": [
+        "#[kani::unwind(0)]"
+      ],
+      "args": {
+        "proof": true,
+        "test": false
+      }
+    },
+    {
+      "name": "function_xyz",
+      "fullLine": "pub fn function_xyz() {",
+      "endPosition": {
+        "row": 11,
+        "column": 19
+      },
+      "attributes": [],
+      "args": {
+        "proof": true,
+        "test": false
+      }
+    },
+    {
+      "name": "function_xyz_2",
+      "fullLine": "unsafe fn function_xyz_2() {",
+      "endPosition": {
+        "row": 19,
+        "column": 24
+      },
+      "attributes": [
+        "#[kani::unwind(2)]",
+        "#[kani::solver(kissat)]"
+      ],
+      "args": {
+        "proof": true,
+        "test": false
+      }
+    },
+    {
+      "name": "function_xyz_3",
+      "fullLine": "pub unsafe fn function_xyz_3() {",
+      "endPosition": {
+        "row": 25,
+        "column": 28
+      },
+      "attributes": [],
+      "args": {
+        "proof": true,
+        "test": false
+      }
+    },
+    {
+      "name": "function_xyz_7",
+      "fullLine": "fn function_xyz_7() {",
+      "endPosition": {
+        "row": 33,
+        "column": 17
+      },
+      "attributes": [
+        "#[kani::unwind(0)]",
+        "#[kani::solver(kissat)]"
+      ],
+      "args": {
+        "proof": true,
+        "test": false
+      }
+    }
+]
+
+
+export const findHarnessesResultBolero =
+[
+    {
+      "name": "insert_test_80978342",
+      "fullLine": "fn insert_test_80978342() {",
+      "endPosition": {
+        "row": 6,
+        "column": 27
+      },
+      "attributes": [
+        "#[cfg_attr(kani, kani::proof, kani::unwind(0))]"
+      ],
+      "args": {
+        "proof": true,
+        "test": true
+      }
+    },
+    {
+      "name": "insert_test_2",
+      "fullLine": "fn insert_test_2() {",
+      "endPosition": {
+        "row": 14,
+        "column": 20
+      },
+      "attributes": [
+        "#[cfg_attr(kani, kani::proof, kani::unwind(1))]"
+      ],
+      "args": {
+        "proof": true,
+        "test": true
+      }
+    },
+    {
+      "name": "random_name",
+      "fullLine": "fn random_name() {",
+      "endPosition": {
+        "row": 22,
+        "column": 18
+      },
+      "attributes": [
+        "#[cfg_attr(kani, kani::proof, kani::unwind(1))]"
+      ],
+      "args": {
+        "proof": true,
+        "test": true
+      }
+    }
+];
+
+export const harnessMetadata = [
+    {
+      "name": "insert_test_80978342",
+      "fullLine": "fn insert_test_80978342() {",
+      "endPosition": {
+        "row": 6,
+        "column": 27
+      },
+      "attributes": [
+        "#[cfg_attr(kani, kani::proof, kani::unwind(0))]"
+      ],
+      "args": {
+        "proof": true,
+        "test": true,
+        "unwind_value": 0
+      }
+    },
+    {
+      "name": "insert_test_2",
+      "fullLine": "fn insert_test_2() {",
+      "endPosition": {
+        "row": 14,
+        "column": 20
+      },
+      "attributes": [
+        "#[cfg_attr(kani, kani::proof, kani::unwind(1))]"
+      ],
+      "args": {
+        "proof": true,
+        "test": true,
+        "unwind_value": 1
+      }
+    },
+    {
+      "name": "random_name",
+      "fullLine": "fn random_name() {",
+      "endPosition": {
+        "row": 22,
+        "column": 18
+      },
+      "attributes": [
+        "#[cfg_attr(kani, kani::proof, kani::unwind(1))]"
+      ],
+      "args": {
+        "proof": true,
+        "test": true,
+        "unwind_value": 1
+      }
+    },
+    {
+      "name": "function_abc",
+      "fullLine": "fn function_abc() {",
+      "endPosition": {
+        "row": 31,
+        "column": 15
+      },
+      "attributes": [
+        "#[kani::unwind(0)]"
+      ],
+      "args": {
+        "proof": true,
+        "test": false,
+        "unwind_value": 0
+      }
+    },
+    {
+      "name": "function_xyz",
+      "fullLine": "pub fn function_xyz() {",
+      "endPosition": {
+        "row": 38,
+        "column": 19
+      },
+      "attributes": [],
+      "args": {
+        "proof": true,
+        "test": false
+      }
+    },
+    {
+      "name": "function_xyz_2",
+      "fullLine": "unsafe fn function_xyz_2() {",
+      "endPosition": {
+        "row": 46,
+        "column": 24
+      },
+      "attributes": [
+        "#[kani::unwind(2)]",
+        "#[kani::solver(kissat)]"
+      ],
+      "args": {
+        "proof": true,
+        "test": false,
+        "unwind_value": 2,
+        "solver": "kissat"
+      }
+    },
+    {
+      "name": "function_xyz_3",
+      "fullLine": "pub unsafe fn function_xyz_3() {",
+      "endPosition": {
+        "row": 52,
+        "column": 28
+      },
+      "attributes": [],
+      "args": {
+        "proof": true,
+        "test": false
+      }
+    },
+    {
+      "name": "function_xyz_7",
+      "fullLine": "fn function_xyz_7() {",
+      "endPosition": {
+        "row": 60,
+        "column": 17
+      },
+      "attributes": [
+        "#[kani::unwind(0)]",
+        "#[kani::solver(kissat)]"
+      ],
+      "args": {
+        "proof": true,
+        "solver": "kissat",
+        "test": false,
+        "unwind_value": 0
+      }
+    }
+]

--- a/src/test/test-programs/stubbedParser.ts
+++ b/src/test/test-programs/stubbedParser.ts
@@ -1,55 +1,55 @@
-// Copyright Kani Contributors
-// SPDX-License-Identifier: Apache-2.0 OR MIT
-import * as parser from '../../ui/sourceCodeParser';
+// // Copyright Kani Contributors
+// // SPDX-License-Identifier: Apache-2.0 OR MIT
+// import * as parser from '../../ui/sourceCodeParser';
 
-const proofRe = /kani::proof.*((.|\n)*?){/gm;
-const testRe = /#\[test].*((.|\n)*?){/gm;
+// const proofRe = /kani::proof.*((.|\n)*?){/gm;
+// const testRe = /#\[test].*((.|\n)*?){/gm;
 
-const parseRustfile = (text: string): any => {
-	const allProofs = text.matchAll(proofRe);
-	const allTests = text.matchAll(testRe);
-	const harnessMap = new Map<string, string>();
-	const map = new Map<string, string>();
-	const harnessList: Set<string> = new Set<string>([]);
-	const testList: Set<string> = new Set<string>([]);
-	const testMap = new Map<string, string>();
-	const unwindMap = new Map<string, number>();
+// const parseRustfile = (text: string): any => {
+// 	const allProofs = text.matchAll(proofRe);
+// 	const allTests = text.matchAll(testRe);
+// 	const harnessMap = new Map<string, string>();
+// 	const map = new Map<string, string>();
+// 	const harnessList: Set<string> = new Set<string>([]);
+// 	const testList: Set<string> = new Set<string>([]);
+// 	const testMap = new Map<string, string>();
+// 	const unwindMap = new Map<string, number>();
 
-	for (const test of allTests) {
-		const [harnessLineRaw, mapLineValue] = parser.getHarnessInformationFromTest(test);
-		const unwindValue = parser.extractUnwindValueFromTest(harnessLineRaw);
-		let harnessLine = parser.extractFunctionLineFromTest(harnessLineRaw);
-		const harnessName = parser.getHarnessNameFromHarnessLine(harnessLine);
-		harnessLine = harnessLine.replace(/\s+/g, '').concat('{');
-		testList.add(harnessName);
-		harnessList.add(harnessName);
-		testMap.set(harnessLine, harnessName);
-		if (!unwindMap.has(harnessLine)) {
-			unwindMap.set(harnessLine, unwindValue);
-		}
-		map.set(harnessLine, mapLineValue);
-	}
+// 	for (const test of allTests) {
+// 		const [harnessLineRaw, mapLineValue] = parser.getHarnessInformationFromTest(test);
+// 		const unwindValue = parser.extractUnwindValueFromTest(harnessLineRaw);
+// 		let harnessLine = parser.extractFunctionLineFromTest(harnessLineRaw);
+// 		const harnessName = parser.getHarnessNameFromHarnessLine(harnessLine);
+// 		harnessLine = harnessLine.replace(/\s+/g, '').concat('{');
+// 		testList.add(harnessName);
+// 		harnessList.add(harnessName);
+// 		testMap.set(harnessLine, harnessName);
+// 		if (!unwindMap.has(harnessLine)) {
+// 			unwindMap.set(harnessLine, unwindValue);
+// 		}
+// 		map.set(harnessLine, mapLineValue);
+// 	}
 
-	for (const test of allProofs) {
-		const [harnessLineRaw, mapLineValue] = parser.getHarnessInformationFromTest(test);
-		const unwindValue = parser.extractUnwindValueFromLine(harnessLineRaw);
-		let harnessLine = parser.extractFunctionLine(harnessLineRaw);
-		const harnessName = parser.getHarnessNameFromHarnessLine(harnessLine);
-		harnessLine = harnessLine.replace(/\s+/g, '');
-		harnessList.add(harnessName);
-		harnessMap.set(harnessLine, harnessName);
-		if (!unwindMap.has(harnessLine)) {
-			unwindMap.set(harnessLine, unwindValue);
-		}
-		map.set(harnessLine, mapLineValue);
-	}
-	return [harnessList, unwindMap];
-};
+// 	for (const test of allProofs) {
+// 		const [harnessLineRaw, mapLineValue] = parser.getHarnessInformationFromTest(test);
+// 		const unwindValue = parser.extractUnwindValueFromLine(harnessLineRaw);
+// 		let harnessLine = parser.extractFunctionLine(harnessLineRaw);
+// 		const harnessName = parser.getHarnessNameFromHarnessLine(harnessLine);
+// 		harnessLine = harnessLine.replace(/\s+/g, '');
+// 		harnessList.add(harnessName);
+// 		harnessMap.set(harnessLine, harnessName);
+// 		if (!unwindMap.has(harnessLine)) {
+// 			unwindMap.set(harnessLine, unwindValue);
+// 		}
+// 		map.set(harnessLine, mapLineValue);
+// 	}
+// 	return [harnessList, unwindMap];
+// };
 
-export function getHarnessListFromParsing(text: string): Set<string> {
-	return parseRustfile(text).at(0);
-}
+// export function getHarnessListFromParsing(text: string): Set<string> {
+// 	return parseRustfile(text).at(0);
+// }
 
-export function getUnwindMapFromParsing(text: string): Map<string, number> {
-	return parseRustfile(text).at(1);
-}
+// export function getUnwindMapFromParsing(text: string): Map<string, number> {
+// 	return parseRustfile(text).at(1);
+// }

--- a/src/ui/reportView/callReport.ts
+++ b/src/ui/reportView/callReport.ts
@@ -40,7 +40,11 @@ interface reportMetadata {
  */
 export async function callViewerReport(
 	commandURI: string,
-	harnessObj: { harnessName: string; harnessFile: string; harnessType: boolean },
+	harnessObj: {
+		harnessName: string;
+		harnessFile: string;
+		harnessType: boolean;
+	},
 ): Promise<void> {
 	let finalCommand: string = '';
 	let searchDir: string = '';
@@ -196,7 +200,10 @@ async function parseReportOutput(stdout: string): Promise<visualizeResult | unde
 			if (process.env.SSH_CONNECTION !== undefined) {
 				// Generate the command using the path to the directory
 				const reportDir = reportPath.replace('/index.html', '');
-				return { isLocal: false, command: 'python3 -m http.server --directory ' + reportDir };
+				return {
+					isLocal: false,
+					command: 'python3 -m http.server --directory ' + reportDir,
+				};
 			} else {
 				return { isLocal: true, path: reportPath };
 			}

--- a/src/ui/sourceCodeParser.ts
+++ b/src/ui/sourceCodeParser.ts
@@ -5,468 +5,231 @@ import * as assert from 'assert';
 import Parser from "tree-sitter";
 import * as vscode from 'vscode';
 
-import { countOccurrences} from '../utils';
-import { FileMetaData, HarnessMetadata } from "./sourceMap";
+import { countOccurrences } from '../utils';
+import { HarnessMetadata } from './sourceMap';
 
 // Parse for kani::proof helper function
-const proofRe = /kani::proof.*((.|\n)*?){/gm;
-const testRe = /#\[test].*((.|\n)*?){/gm;
-const kaniConfig = '#[cfg_attr(kani';
-const functionModifiers = ['pub', 'async', 'unsafe', 'const', 'extern'];
-const target = "attribute_item";
-const Rust = require("tree-sitter-rust");
+const Rust = require('tree-sitter-rust');
 const parser = new Parser();
 parser.setLanguage(Rust);
 
-// use the tree sitter to get attributes
-function getAttributeFromRustFile(file: string): any {
-	const tree = parser.parse(file);
-	const nodes = tree.rootNode.namedChildren;
+export namespace SourceCodeParser {
 
-	const harnesses = searchParseTreeForFunctions(tree.rootNode);
- 	const search_results = searchParseTree(tree.rootNode);
-	return search_results;
-}
+	// Return True if proofs exist in the file, False if not
+	export function checkFileForProofs(content: string): boolean {
+		return checkTextForProofs(content);
+	}
 
-// Search if there exists a kani attribute
-function searchParseTree(node: any) : any {
+	// Match source text for Kani annotations
+	export const checkTextForProofs = (content: string): boolean => {
+		const tree = parser.parse(content);
+		return checkforKani(tree.rootNode);
+	};
 
-	// check for the kani::proof attribute
-	const results = [];
-	if (node.type === target) {
-		if(countOccurrences(node.text, "kani::proof") == 1)
-		{
-			results.push(node);
+	// Use the tree sitter to get attributes
+	export function getAttributeFromRustFile(file: string): HarnessMetadata[] {
+		const tree = parser.parse(file);
+		const harnesses = searchParseTreeForFunctions(tree.rootNode);
+		const sortedHarnessByline = [...harnesses].sort(
+			(a, b) => a.endPosition.row - b.endPosition.row,
+		);
+		// Fill argument values
+		fillMetadataForFile(sortedHarnessByline);
+		return sortedHarnessByline;
+	}
+
+	// Do DFS to get all harnesses
+	export function searchParseTreeForFunctions(node: any): HarnessMetadata[] {
+		const results: any[] = [];
+		if (!node.namedChildren) {
+			return results;
 		}
-	  } else if (node.namedChildren) {
+		const harness_results = findHarnesses(node.namedChildren);
+		if (harness_results.length > 0) {
+			results.push(...harness_results);
+		}
 		for (let i = 0; i < node.namedChildren.length; i++) {
-		  const result = searchParseTree(node.namedChildren[i]);
-		  if (result.length != 0) {
-			results.push(...result);
-		  }
+			if (node.namedChildren[i].namedChildren) {
+				const result = searchParseTreeForFunctions(node.namedChildren[i]);
+				if (result.length != 0) {
+					results.push(...result);
+				}
+			}
 		}
-	  }
-	return results;
-}
-
-// Do DFS to get all harnesses
-function searchParseTreeForFunctions(node: any) : any[] {
-
-	const results: any[] = [];
-	if(!node.namedChildren) {
 		return results;
 	}
-	const harness_results = findHarnesses(node.namedChildren);
-	if(harness_results.length > 0)
-	{
-		results.push(...harness_results);
-	}
-	for (let i = 0; i < node.namedChildren.length; i++) {
-		if(node.namedChildren[i].namedChildren){
-			const result = searchParseTreeForFunctions(node.namedChildren[i]);
-			if (result.length != 0) {
-				results.push(...result);
-			}
-		}
-	}
-	return results;
-}
 
-function findHarnesses(strList: any[]): any {
-	const result: any[] = [];
-	for (let i = 0; i < strList.length; i++) {
-		if (strList[i].type == "attribute_item" && strList[i].text.includes("kani::proof")) {
-			for (let j = i; j < strList.length; j++) {
-				if (strList[j].type == "function_item") {
-					result.push(strList[j]);
-					break;
-				}
-			}
-		}
-	}
-	return result;
-}
+	// Given a list of nodes, return the function subnodes as a list
+	export function findHarnesses(strList: any[]): HarnessMetadata[] {
+		const resultMap: HarnessMetadata[] = [];
+		for (let i = 0; i < strList.length; i++) {
+			if (strList[i].type == 'attribute_item' && strList[i].text.includes('kani::proof')) {
+				// Capture also, items that might be related to kani i.e other attributes in the same line or different lines
+				// they will contain the words kani
+				const attributes: any[] = [];
+				const attributesMetadata: any[] = [];
+				let test_bool: boolean = false;
+				for (let j = i; j < strList.length; j++) {
+					if (strList[j].type == 'attribute_item' && strList[j].text.includes('kani')) {
+						// Check if test is above and if its in the form of cfg_attr()
+						if (j >= 1 && strList[j - 1].type == 'attribute_item') {
+							test_bool = strList[j - 1].text.includes('test');
+						}
 
-// Search if there exists a kani attribute
-function checkforKani(node: any) : boolean {
-
-	// check for the kani::proof attribute
-	if (node.type === target && countOccurrences(node.text, "kani::proof") == 1) {
-		return true;
-	} else if (node.namedChildren) {
-		for (let i = 0; i < node.namedChildren.length; i++) {
-		  	if(checkforKani(node.namedChildren[i])) {
-				return true;
-			}
-			else {
-				continue;
-			}
-		}
-	}
-	return false;
-}
-
-
-function fillMetadataForFile(harnesses: HarnessMetadata[]): void {
-	for(const harness of harnesses) {
-		fillMetadataValue(harness);
-	}
-}
-
-function fillMetadataValue(harness: HarnessMetadata): void {
-	for(const attribute of harness.attributes) {
-		if(attribute.includes("kani::unwind")) {
-			const unwindValue = extractUnwindValueNew(attribute);
-			harness.args.unwind_value = unwindValue;
-		}
-		else if(attribute.includes("kani::solver")) {
-			const solverName = extractSolverValueNew(attribute);
-			harness.args.solver = solverName;
-		}
-		else {
-			break;
-		}
-	}
-}
-
-// Match source text for Kani annotations
-export const checkTextForProofs = (content: string): boolean => {
-	const tree = parser.parse(content);
-	return checkforKani(tree.rootNode);
-};
-
-/**
- * Find kani proof and bolero proofs and extract metadata out of them from source text
- *
- * @param text - raw source text from a file
- * @param events - events that trigger parsing and extracting the harness metadata
- */
-export const parseRustfile = (
-	text: string,
-	events: {
-		onTest(range: vscode.Range, name: string, harnessType: boolean, harnessArgs?: number): void;
-	},
-): void => {
-	const allProofs = text.matchAll(proofRe);
-	const allTests = text.matchAll(testRe);
-
-	// Create harness metadata for the entire file
-	const allAttributes: HarnessMetadata[] = getAttributeFromRustFile(text);
-	const harnessesSortedByLine: HarnessMetadata[] = [...allAttributes].sort((a,b) => a.endPosition.row - b.endPosition.row);
-
-	// Fill argument values
-	fillMetadataForFile(harnessesSortedByLine);
-	console.log(JSON.stringify(harnessesSortedByLine, undefined, 2));
-
-	const harnessMap = new Map<string, string>();
-	const map = new Map<string, string>();
-	const harnessList: Set<string> = new Set<string>([]);
-	const testList: Set<string> = new Set<string>([]);
-	const testMap = new Map<string, string>();
-	const unwindMap = new Map<string, number>();
-
-	// Bolero proofs
-	for (const test of allTests) {
-		const [harnessLineRaw, mapLineValue]: [string, string] = getHarnessInformationFromTest(test);
-		const unwindValue: number = extractUnwindValueFromTest(harnessLineRaw);
-		let harnessLine: string = extractFunctionLineFromTest(harnessLineRaw);
-		const harnessName: string = getHarnessNameFromHarnessLine(harnessLine);
-		harnessLine = harnessLine.replace(/\s+/g, '').concat('{');
-		testList.add(harnessName);
-		harnessList.add(harnessName);
-		testMap.set(harnessLine, harnessName);
-		if (!unwindMap.has(harnessLine)) {
-			unwindMap.set(harnessLine, unwindValue);
-		}
-		map.set(harnessLine, mapLineValue);
-	}
-
-	// Kani proofs
-	for (const test of allProofs) {
-		const [harnessLineRaw, mapLineValue]: [string, string] = getHarnessInformationFromTest(test);
-		const unwindValue: number = extractUnwindValueFromLine(harnessLineRaw);
-		let harnessLine: string = extractFunctionLine(harnessLineRaw);
-		const harnessName: string = getHarnessNameFromHarnessLine(harnessLine);
-		harnessLine = harnessLine.replace(/\s+/g, '');
-		harnessList.add(harnessName);
-		harnessMap.set(harnessLine, harnessName);
-		if (!unwindMap.has(harnessLine)) {
-			unwindMap.set(harnessLine, unwindValue);
-		}
-		map.set(harnessLine, mapLineValue);
-	}
-
-	const lines = text.split('\n');
-	if (harnessList.size > 0) {
-		for (let lineNo = 0; lineNo < lines.length; lineNo++) {
-			// Get the current line from source and check if
-			// the maps contain the line or not
-			const line: string = lines[lineNo];
-			let strippedLine: string = line.replace(/\s+/g, '');
-
-			// Add the parsed node for the current line
-			const harness = allAttributes.find((p) => p.endPosition.row === lineNo);
-			if(harness) {
-				assert.equal(harness.fullLine, line.trim());
-				const name: string = harness.name;
-				const unwind = harness.args.unwind_value;
-
-				// Range should cover the entire harness
-				const range = new vscode.Range(
-					new vscode.Position(lineNo, 0),
-					new vscode.Position(lineNo, line.length),
-				);
-			}
-
-			for (const fnMod of functionModifiers) {
-				if (strippedLine.startsWith(fnMod)) {
-					strippedLine = strippedLine.replace(fnMod, '');
-				}
-			}
-			if (harnessMap.has(strippedLine)) {
-				const name: string = harnessMap.get(strippedLine)!;
-				const unwind: number = unwindMap.get(strippedLine)!;
-				// Range should cover the entire harness
-				const range = new vscode.Range(
-					new vscode.Position(lineNo, 0),
-					new vscode.Position(lineNo, line.length),
-				);
-				// Pass the harness onto the test item
-				if (testMap.has(strippedLine)) {
-					// Check for potential flags passed under the annotations
-					if (!isNaN(unwind)) {
-						events.onTest(range, name, false, unwind);
-					} else {
-						events.onTest(range, name, false);
+						// Get all attributes for the proof
+						if (strList[j].text != '#[kani::proof]') {
+							attributes.push(strList[j]);
+							attributesMetadata.push(strList[j].text);
+						}
 					}
+
+					// Proceed to the attached function, and create the harness
+					// todo: assert that attributes and function are siblings to each other or not
+					if (strList[j].type == 'function_item') {
+						const functionName = strList[j].namedChildren.find(
+							(p: { type: string }) => p.type === 'identifier',
+						);
+						const unprocessedLine = strList[j].text.split('\n')[0];
+						const current_harness: HarnessMetadata = {
+							name: functionName.text,
+							fullLine: unprocessedLine,
+							endPosition: functionName.endPosition,
+							attributes: attributesMetadata,
+							args: { proof: true, test: test_bool },
+						};
+						resultMap.push(current_harness);
+						break;
+					}
+				}
+			}
+		}
+		return resultMap;
+	}
+
+	// Search if there exists a kani attribute
+	export function checkforKani(node: any): boolean {
+		// check for the kani::proof attribute
+		if (node.type === 'attribute_item' && countOccurrences(node.text, 'kani::proof') == 1) {
+			return true;
+		} else if (node.namedChildren) {
+			for (let i = 0; i < node.namedChildren.length; i++) {
+				if (checkforKani(node.namedChildren[i])) {
+					return true;
 				} else {
-					if (!isNaN(unwind)) {
-						events.onTest(range, name, true, unwind);
-					} else {
-						events.onTest(range, name, true);
-					}
+					continue;
 				}
-				continue;
+			}
+		}
+		return false;
+	}
+
+	// Search if there exists a kani attribute
+	export function fillMetadataForFile(harnesses: HarnessMetadata[]): void {
+		for (const harness of harnesses) {
+			fillMetadataValue(harness);
+		}
+	}
+
+	export function fillMetadataValue(harness: HarnessMetadata): void {
+		for (const attribute of harness.attributes) {
+			if (attribute.includes('kani::unwind')) {
+				const unwindValue = extractUnwindValue(attribute);
+				harness.args.unwind_value = unwindValue;
+			}
+			if (attribute.includes('kani::solver')) {
+				const solverName = extractSolverValue(attribute);
+				harness.args.solver = solverName;
 			}
 		}
 	}
-};
 
-/**
- * Given a bolero test case, extract the unwind integer value
- *
- * @param harnessLineRaw - unprocessed line from the source text
- * @returns - Unwind value as integer
- */
-export function extractUnwindValueFromTest(harnessLineRaw: string): number {
-	let unwindValue: number = NaN;
-	const harnessLineSplit = harnessLineRaw.split('\n');
-	if (searchKaniConfig(harnessLineSplit)) {
-		unwindValue = extractUnwindValue(harnessLineSplit);
-	} else {
+	/**
+	 * Find kani proof and bolero proofs and extract metadata out of them from source text
+	 *
+	 * @param text - raw source text from a file
+	 * @param events - events that trigger parsing and extracting the harness metadata
+	 */
+	export const parseRustfile = (
+		text: string,
+		events: {
+			onTest(range: vscode.Range, name: string, proofBoolean: boolean, harnessArgs?: number): void;
+		},
+	): void => {
+		// Create harness metadata for the entire file
+		const allHarnesses: HarnessMetadata[] = getAttributeFromRustFile(text);
+		console.log(JSON.stringify(allHarnesses, undefined, 2));
+		const lines = text.split('\n');
+		if (allHarnesses.length > 0) {
+			for (let lineNo = 0; lineNo < lines.length; lineNo++) {
+				// Get the current line from source and check if
+				// the maps contain the line or not
+				const line: string = lines[lineNo];
+
+				// Add the parsed node for the current line
+				const harness = allHarnesses.find((p) => p.endPosition.row === lineNo);
+				if (harness) {
+					assert.equal(harness.fullLine, line.trim());
+
+					const name: string = harness.name;
+					const unwind = harness.args.unwind_value;
+					// Range should cover the entire harness
+					const range = new vscode.Range(
+						new vscode.Position(lineNo, 0),
+						new vscode.Position(lineNo, line.length),
+					);
+
+					// Check if it's a proof (true) or a bolero case (false)
+					const proofBoolean = !harness.args.test;
+
+					if (unwind == undefined) {
+						events.onTest(range, name, proofBoolean);
+					} else {
+						events.onTest(range, name, proofBoolean, unwind);
+					}
+				}
+			}
+		}
+	};
+
+	/**
+	 * Given any array of lines of code containing kani annotations, extract the integer corresponding
+	 * to the unwind value and return
+	 *
+	 * @param harnessLineSplit - Array of source lines that belong to the harness
+	 * @returns unwind value
+	 */
+	export function extractUnwindValue(harnessLine: string): number {
+		if (harnessLine.includes('kani::unwind(')) {
+			const unwindValueAsString = harnessLine.match(/\d+/);
+			if(unwindValueAsString == undefined) {
+				return NaN;
+			}
+			const unwindValue: number = parseInt(unwindValueAsString[0]);
+			return isNaN(unwindValue) ? NaN : unwindValue;
+		}
+
+		// Technically never called, but a good failsafe to have
 		return NaN;
 	}
-	return unwindValue;
-}
 
-/**
- * Given any array of lines of code containing kani annotations, extract the integer corresponding
- * to the unwind value and return
- *
- * @param harnessLineSplit - Array of source lines that belong to the harness
- * @returns unwind value
- */
-export function extractUnwindValue(harnessLineSplit: string[]): number {
-	for (let x of harnessLineSplit) {
-		x = x.trim();
-
-		if (x.includes('kani::unwind(')) {
-			const unwindValue: number = parseInt(x.match(/\d+/)![0]);
-			return unwindValue;
+	/**
+	 * Given any array of lines of code containing kani annotations, extract the integer corresponding
+	 * to the unwind value and return
+	 *
+	 * @param harnessLineSplit - Array of source lines that belong to the harness
+	 * @returns unwind value
+	 */
+	export function extractSolverValue(str: string): string {
+		const keyword = "::solver(";
+		const start = str.indexOf(keyword);
+		if (start === -1) {
+			return "";
 		}
-	}
-
-	return NaN;
-}
-
-/**
- * Given any array of lines of code containing kani annotations, extract the integer corresponding
- * to the unwind value and return
- *
- * @param harnessLineSplit - Array of source lines that belong to the harness
- * @returns unwind value
- */
-export function extractUnwindValueNew(harnessLine: string): number {
-
-	if (harnessLine.includes('kani::unwind(')) {
-		const unwindValue: number = parseInt(harnessLine.match(/\d+/)![0]);
-		return unwindValue;
-	}
-
-	return NaN;
-}
-
-/**
- * Given any array of lines of code containing kani annotations, extract the integer corresponding
- * to the unwind value and return
- *
- * @param harnessLineSplit - Array of source lines that belong to the harness
- * @returns unwind value
- */
-export function extractSolverValueNew(str: string): string {
-	const prefix = '#[kani::solver("';
-	const suffix = '")';
-	const startIndex = str.indexOf(prefix);
-	// if (startIndex === -1) {
-	// 	return "";
-	// }
-	const endIndex = str.indexOf(suffix, startIndex + prefix.length);
-	// if (endIndex === -1) {
-	// 	return "";
-	// }
-
-	const value = str.slice(startIndex + prefix.length, endIndex-1);
-
-	return value;
-}
-
-/**
- * Return unwind value given a string containing the bolero proof and it's matching harness case
- *
- * @param harnessLineRaw - Unprocessed source line
- * @returns - unwind value
- */
-export function extractUnwindValueFromLine(harnessLineRaw: string): number {
-	let unwindValue: number = NaN;
-	let harnessLine = '';
-	if (!harnessLineRaw.startsWith('fn')) {
-		if (harnessLineRaw.charAt(0) === '\n') {
-			harnessLine = harnessLineRaw.replace('\n', '').concat('{');
+		const end = str.indexOf(")", start);
+		if (end === -1) {
+			return "";
 		}
+		const substringStart = start + keyword.length;
+		return str.substring(substringStart, end);
 	}
-	const harnessLineSplit = harnessLine.split('\n');
-	unwindValue = extractUnwindValue(harnessLineSplit);
-	return unwindValue;
-}
-
-/**
- *  Given a source line, extract the function name from the bolero test case
- *
- * @param harnessLineRaw - unprocessed line from the source text
- * @returns - name of the function containing proof annotation
- */
-export function extractFunctionLineFromTest(harnessLineRaw: string): string {
-	let harnessLine: string = '';
-	const harnessLineSplit = harnessLineRaw.split('\n');
-	if (searchKaniConfig(harnessLineSplit)) {
-		harnessLine = cleanFunctionLine(harnessLineSplit);
-	} else {
-		return '';
-	}
-	return harnessLine;
-}
-
-/**
- * Extract function name from the line
- *
- * @param harnessLineRaw - unprocessed line from the source text
- * @returns - function name
- */
-export function extractFunctionLine(harnessLineRaw: string): string {
-	let harnessLine: string = '';
-	if (!harnessLineRaw.startsWith('fn')) {
-		if (harnessLineRaw.charAt(0) === '\n') {
-			harnessLine = harnessLineRaw.replace('\n', '').concat('{');
-		}
-	}
-	const harnessLineSplit = harnessLine.split('\n');
-	harnessLine = cleanFunctionLine(harnessLineSplit);
-	return harnessLine;
-}
-
-/**
- * Clean out noise from the raw line and return the function name
- *
- * @param harnessLineSplit - Array of source lines that belong to the harness
- * @returns - function name
- */
-export function cleanFunctionLine(harnessLineSplit: string[]): string {
-	for (let x of harnessLineSplit) {
-		x = x.trim();
-		if (x.startsWith('fn')) {
-			return x;
-		}
-		if (
-			x.startsWith('pub') ||
-			x.startsWith('async') ||
-			x.startsWith('extern') ||
-			x.startsWith('const') ||
-			x.startsWith('unsafe')
-		) {
-			const functionNameSplit: string[] = x.split('fn');
-			if (functionNameSplit.length >= 2) {
-				const functionName: string = 'fn ' + functionNameSplit[1].trim();
-				return functionName;
-			} else {
-				return '';
-			}
-		}
-	}
-	return harnessLineSplit.join('');
-}
-
-/**
- * Extract the harness name given the processed source line
- *
- * @param harnessLine - Post processed and cleaned source line
- * @returns - harness name
- */
-export function getHarnessNameFromHarnessLine(harnessLine: string): string {
-	const harnessLineSplit: string[] = harnessLine.split(' ');
-
-	if (
-		harnessLineSplit === undefined ||
-		harnessLineSplit.length < 2 ||
-		harnessLineSplit.at(1) === undefined
-	) {
-		return '';
-	}
-
-	const harnessNamePostFunction: string | undefined = harnessLineSplit.at(1);
-
-	if (harnessNamePostFunction === undefined || harnessNamePostFunction.split('(').length === 0) {
-		return '';
-	}
-
-	const harnessName: string | undefined = harnessNamePostFunction.split('(').at(0);
-	if (harnessName === undefined) {
-		return '';
-	}
-	return harnessName;
-}
-
-/**
- * util function to return matched regex patterns
- *
- * @param test - Match Array from RegEx
- * @returns Tuple from unprocessed line that matches regex and corresponding harness
- */
-export function getHarnessInformationFromTest(test: RegExpMatchArray): [string, string] {
-	if (!test || test.length < 2) {
-		throw new Error('Regex Match incorrect');
-	}
-	const harnessLineRaw: string = test.at(1) as string;
-	const mapLineValue: string = test.at(0) as string;
-
-	return [harnessLineRaw, mapLineValue];
-}
-
-// Util function to search for kani annotation as a substring in the array of regex matches
-function searchKaniConfig(harnessLineSplit: string[]): boolean {
-	for (const line of harnessLineSplit) {
-		if (line.includes(kaniConfig)) {
-			return true;
-		}
-	}
-	return false;
 }

--- a/src/ui/sourceCodeParser.ts
+++ b/src/ui/sourceCodeParser.ts
@@ -1,25 +1,138 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
+import * as assert from 'assert';
+
+import Parser from "tree-sitter";
 import * as vscode from 'vscode';
+
+import { countOccurrences} from '../utils';
+import { FileMetaData, HarnessMetadata } from "./sourceMap";
 
 // Parse for kani::proof helper function
 const proofRe = /kani::proof.*((.|\n)*?){/gm;
 const testRe = /#\[test].*((.|\n)*?){/gm;
 const kaniConfig = '#[cfg_attr(kani';
 const functionModifiers = ['pub', 'async', 'unsafe', 'const', 'extern'];
+const target = "attribute_item";
+const Rust = require("tree-sitter-rust");
+const parser = new Parser();
+parser.setLanguage(Rust);
 
-// Return True if proofs exist in the file, False if not
-export function checkFileForProofs(content: string): boolean {
-	return checkTextForProofs(content);
+// use the tree sitter to get attributes
+function getAttributeFromRustFile(file: string): any {
+	const tree = parser.parse(file);
+	const nodes = tree.rootNode.namedChildren;
+
+	const harnesses = searchParseTreeForFunctions(tree.rootNode);
+ 	const search_results = searchParseTree(tree.rootNode);
+	return search_results;
+}
+
+// Search if there exists a kani attribute
+function searchParseTree(node: any) : any {
+
+	// check for the kani::proof attribute
+	const results = [];
+	if (node.type === target) {
+		if(countOccurrences(node.text, "kani::proof") == 1)
+		{
+			results.push(node);
+		}
+	  } else if (node.namedChildren) {
+		for (let i = 0; i < node.namedChildren.length; i++) {
+		  const result = searchParseTree(node.namedChildren[i]);
+		  if (result.length != 0) {
+			results.push(...result);
+		  }
+		}
+	  }
+	return results;
+}
+
+// Do DFS to get all harnesses
+function searchParseTreeForFunctions(node: any) : any[] {
+
+	const results: any[] = [];
+	if(!node.namedChildren) {
+		return results;
+	}
+	const harness_results = findHarnesses(node.namedChildren);
+	if(harness_results.length > 0)
+	{
+		results.push(...harness_results);
+	}
+	for (let i = 0; i < node.namedChildren.length; i++) {
+		if(node.namedChildren[i].namedChildren){
+			const result = searchParseTreeForFunctions(node.namedChildren[i]);
+			if (result.length != 0) {
+				results.push(...result);
+			}
+		}
+	}
+	return results;
+}
+
+function findHarnesses(strList: any[]): any {
+	const result: any[] = [];
+	for (let i = 0; i < strList.length; i++) {
+		if (strList[i].type == "attribute_item" && strList[i].text.includes("kani::proof")) {
+			for (let j = i; j < strList.length; j++) {
+				if (strList[j].type == "function_item") {
+					result.push(strList[j]);
+					break;
+				}
+			}
+		}
+	}
+	return result;
+}
+
+// Search if there exists a kani attribute
+function checkforKani(node: any) : boolean {
+
+	// check for the kani::proof attribute
+	if (node.type === target && countOccurrences(node.text, "kani::proof") == 1) {
+		return true;
+	} else if (node.namedChildren) {
+		for (let i = 0; i < node.namedChildren.length; i++) {
+		  	if(checkforKani(node.namedChildren[i])) {
+				return true;
+			}
+			else {
+				continue;
+			}
+		}
+	}
+	return false;
+}
+
+
+function fillMetadataForFile(harnesses: HarnessMetadata[]): void {
+	for(const harness of harnesses) {
+		fillMetadataValue(harness);
+	}
+}
+
+function fillMetadataValue(harness: HarnessMetadata): void {
+	for(const attribute of harness.attributes) {
+		if(attribute.includes("kani::unwind")) {
+			const unwindValue = extractUnwindValueNew(attribute);
+			harness.args.unwind_value = unwindValue;
+		}
+		else if(attribute.includes("kani::solver")) {
+			const solverName = extractSolverValueNew(attribute);
+			harness.args.solver = solverName;
+		}
+		else {
+			break;
+		}
+	}
 }
 
 // Match source text for Kani annotations
-export const checkTextForProofs = (text: string): boolean => {
-	const count = (str: string): number => {
-		return ((str || '').match(proofRe) || []).length;
-	};
-
-	return count(text) > 0;
+export const checkTextForProofs = (content: string): boolean => {
+	const tree = parser.parse(content);
+	return checkforKani(tree.rootNode);
 };
 
 /**
@@ -36,6 +149,15 @@ export const parseRustfile = (
 ): void => {
 	const allProofs = text.matchAll(proofRe);
 	const allTests = text.matchAll(testRe);
+
+	// Create harness metadata for the entire file
+	const allAttributes: HarnessMetadata[] = getAttributeFromRustFile(text);
+	const harnessesSortedByLine: HarnessMetadata[] = [...allAttributes].sort((a,b) => a.endPosition.row - b.endPosition.row);
+
+	// Fill argument values
+	fillMetadataForFile(harnessesSortedByLine);
+	console.log(JSON.stringify(harnessesSortedByLine, undefined, 2));
+
 	const harnessMap = new Map<string, string>();
 	const map = new Map<string, string>();
 	const harnessList: Set<string> = new Set<string>([]);
@@ -81,6 +203,21 @@ export const parseRustfile = (
 			// the maps contain the line or not
 			const line: string = lines[lineNo];
 			let strippedLine: string = line.replace(/\s+/g, '');
+
+			// Add the parsed node for the current line
+			const harness = allAttributes.find((p) => p.endPosition.row === lineNo);
+			if(harness) {
+				assert.equal(harness.fullLine, line.trim());
+				const name: string = harness.name;
+				const unwind = harness.args.unwind_value;
+
+				// Range should cover the entire harness
+				const range = new vscode.Range(
+					new vscode.Position(lineNo, 0),
+					new vscode.Position(lineNo, line.length),
+				);
+			}
+
 			for (const fnMod of functionModifiers) {
 				if (strippedLine.startsWith(fnMod)) {
 					strippedLine = strippedLine.replace(fnMod, '');
@@ -92,7 +229,7 @@ export const parseRustfile = (
 				// Range should cover the entire harness
 				const range = new vscode.Range(
 					new vscode.Position(lineNo, 0),
-					new vscode.Position(lineNo, map.get(strippedLine)![0].length),
+					new vscode.Position(lineNo, line.length),
 				);
 				// Pass the harness onto the test item
 				if (testMap.has(strippedLine)) {
@@ -150,6 +287,47 @@ export function extractUnwindValue(harnessLineSplit: string[]): number {
 	}
 
 	return NaN;
+}
+
+/**
+ * Given any array of lines of code containing kani annotations, extract the integer corresponding
+ * to the unwind value and return
+ *
+ * @param harnessLineSplit - Array of source lines that belong to the harness
+ * @returns unwind value
+ */
+export function extractUnwindValueNew(harnessLine: string): number {
+
+	if (harnessLine.includes('kani::unwind(')) {
+		const unwindValue: number = parseInt(harnessLine.match(/\d+/)![0]);
+		return unwindValue;
+	}
+
+	return NaN;
+}
+
+/**
+ * Given any array of lines of code containing kani annotations, extract the integer corresponding
+ * to the unwind value and return
+ *
+ * @param harnessLineSplit - Array of source lines that belong to the harness
+ * @returns unwind value
+ */
+export function extractSolverValueNew(str: string): string {
+	const prefix = '#[kani::solver("';
+	const suffix = '")';
+	const startIndex = str.indexOf(prefix);
+	// if (startIndex === -1) {
+	// 	return "";
+	// }
+	const endIndex = str.indexOf(suffix, startIndex + prefix.length);
+	// if (endIndex === -1) {
+	// 	return "";
+	// }
+
+	const value = str.slice(startIndex + prefix.length, endIndex-1);
+
+	return value;
 }
 
 /**

--- a/src/ui/sourceMap.ts
+++ b/src/ui/sourceMap.ts
@@ -1,0 +1,38 @@
+export interface FileMetaData {
+    fileName: string,
+    filePath: string,
+    crateName: string,
+    cratePath: string,
+    harnesses: HarnessMetadata[]
+}
+
+export interface HarnessMetadata {
+    name: string,
+    fullLine: string,
+    endPosition: Position,
+    attributes: string[],
+    args: AttributeMetaData,
+}
+
+export interface AttributeMetaData {
+    /// Whether the harness has been annotated with proof.
+    proof: boolean,
+    /// Whethere the harness has been annotated with test (bolero cases)
+    test: boolean,
+    /// Optional data to store solver.
+    solver?: string
+    /// Optional data to store unwind value.
+    unwind_value?: number
+    /// The stubs used in this harness.
+    stubs?: Stub[],
+}
+
+export interface Stub {
+    original: string,
+    replacement: string,
+}
+
+interface Position {
+    column: number,
+    row: number
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,6 +56,25 @@ export function checkCargoExist(): boolean {
 	}
 }
 
+export function countOccurrences(largerString: string, substring: string): number {
+	let count = 0;
+	let startIndex = 0;
+
+	while (true) {
+	  startIndex = largerString.indexOf(substring, startIndex);
+
+	  if (startIndex === -1) {
+		// Substring not found
+		break;
+	  }
+
+	  count++;
+	  startIndex += substring.length;
+	}
+
+	return count;
+  }
+
 // Return the constructed kani invokation and the argument array
 export function splitCommand(command: string): CommandArgs {
 	const parts = parseCommand(command)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
 		"noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		"noImplicitAny": true,
 		"strictPropertyInitialization": true,
+		"esModuleInterop": true,
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
 		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
 		"resolveJsonModule": true,


### PR DESCRIPTION
### Description of changes: 

This PR adds the tree sitter to do the parsing for the rust code. Tree sitters are 

1. More extendable and therefore more scalable
2. More powerful or come with more features
3. Faster
4. More secure

than the traditional regex parsing that we were doing earlier. The performance of the parsing should be faster as well as cheaper computationally now.

This PR also adds structured parsing for the harness metadata and adds improved testing for the parsing module as well.

### Resolved issues:

Resolves #29 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

1. This PR has conflicts with the prototype.
2. Requires installation of the tree sitter library as an external dependency.

### Testing:

* How is this change tested? Manual and Unit testing

* Is this a refactor change? Yes

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
