### PR TITLE
Fix visualization process

### DIFF
--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -17,8 +17,13 @@ import { responseParserInterface } from './kaniOutputParser';
  * @returns the path for the binary cargo-kani (either the installed binary or the development one)
  */
 export function getKaniPath(kaniCommand: string): Promise<string> {
+
+	const options = {
+		shell: false,
+	};
+
 	return new Promise((resolve, reject) => {
-		execFile('which', [kaniCommand], (error, stdout, stderr) => {
+		execFile('which', [kaniCommand], options, (error, stdout, stderr) => {
 			if (error) {
 				console.error(`execFile error: ${error}`);
 				return;

--- a/src/ui/reportView/callReport.ts
+++ b/src/ui/reportView/callReport.ts
@@ -9,9 +9,9 @@ import * as vscode from 'vscode';
 import { KaniArguments, KaniConstants } from '../../constants';
 import { checkCargoExist, getRootDir } from '../../utils';
 
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
 const { promisify } = require('util');
-const execPromise = promisify(exec);
+const execPromise = promisify(execFile);
 const warningMessage = `Report generation is an unstable feature.
 Coverage information has been disabled due recent issues involving incorrect results.`;
 

--- a/src/ui/reportView/callReport.ts
+++ b/src/ui/reportView/callReport.ts
@@ -151,7 +151,7 @@ async function runVisualizeCommand(command: string, harnessName: string): Promis
 		const directory = path.resolve(getRootDir());
 		const commmandSplit: CommandArgs = splitCommand(command);
 
-		// Get cargo command and args for the command to be executed
+		// Get args for the command to be executed
 		const args = commmandSplit.args;
 
 		const options = {

--- a/src/ui/reportView/callReport.ts
+++ b/src/ui/reportView/callReport.ts
@@ -52,7 +52,6 @@ export async function callViewerReport(
 
 	const platform: NodeJS.Platform = process.platform;
 	const harnessName: string = harnessObj.harnessName;
-	const harnessFile: string = harnessObj.harnessFile;
 	const harnessType: boolean = harnessObj.harnessType;
 
 	// Detect source file
@@ -62,7 +61,6 @@ export async function callViewerReport(
 	if (platform === 'darwin' || platform == 'linux') {
 		const responseObject: htmlMetaData = createCommand(
 			commandURI,
-			harnessFile,
 			harnessName,
 			harnessType,
 		);
@@ -126,28 +124,20 @@ async function showReportMetadata(
 // Check if cargo toml exists and create corresponding kani command
 function createCommand(
 	commandURI: string,
-	harnessFile: string,
 	harnessName: string,
 	harnessType: boolean,
 ): htmlMetaData {
 	// Check if cargo toml exists
-	const isCargo = checkCargoExist();
 	let finalCommand: string = '';
 	let searchDir: string = '';
 
-	if (!isCargo) {
-		const command: string = commandURI === 'Kani.runViewerReport' ? 'kani' : 'cargo kani';
-		finalCommand = `${command} ${harnessFile} --harness ${harnessName} --enable-unstable --visualize`;
-		searchDir = path.join(getRootDir());
+	if (harnessType) {
+		const command: string = commandURI === 'Kani.runViewerReport' ? 'cargo kani' : 'kani';
+		finalCommand = `${command} --harness ${harnessName} --enable-unstable --visualize`;
+		searchDir = path.join(getRootDir(), 'target');
 	} else {
-		if (harnessType) {
-			const command: string = commandURI === 'Kani.runViewerReport' ? 'cargo kani' : 'kani';
-			finalCommand = `${command} --harness ${harnessName} --enable-unstable --visualize`;
-			searchDir = path.join(getRootDir(), 'target');
-		} else {
-			finalCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName} --enable-unstable --visualize`;
-			searchDir = path.join(getRootDir(), 'target');
-		}
+		finalCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName} --enable-unstable --visualize`;
+		searchDir = path.join(getRootDir(), 'target');
 	}
 
 	return { finalCommand, searchDir };

--- a/src/ui/reportView/callReport.ts
+++ b/src/ui/reportView/callReport.ts
@@ -59,11 +59,7 @@ export async function callViewerReport(
 
 	// Generate the final visualize command for the supported platforms
 	if (platform === 'darwin' || platform == 'linux') {
-		const responseObject: htmlMetaData = createCommand(
-			commandURI,
-			harnessName,
-			harnessType,
-		);
+		const responseObject: htmlMetaData = createCommand(commandURI, harnessName, harnessType);
 		const crateURI: string = getRootDir();
 		finalCommand = `${responseObject.finalCommand}`;
 		searchDir = responseObject.searchDir;
@@ -174,8 +170,7 @@ async function runVisualizeCommand(command: string, harnessName: string): Promis
 		console.error(`stderr: ${stderr}`);
 
 		return { statusCode: 0, result: parseResult };
-	}
-	catch (error) {
+	} catch (error) {
 		console.error(`exec error: ${error}`);
 		return { statusCode: 1, result: undefined, error: error as string };
 	}


### PR DESCRIPTION
### Description of changes: 

The visualization process was still using `exec` to do the process spawning and needed to be replaced with `execFile`.
It adds `shell=false`, which was missing, and now doesn't spawn a new shell for `execFile`.

### Testing:

* How is this change tested? Manually

* Is this a refactor change? Yes

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
