### PR TITLE
Add concrete playback button for Failed Proofs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -196,6 +196,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		},
 	);
 
+	// Register the run viewer report command
+	const runningConcretePlayback = vscode.commands.registerCommand(
+		'Kani.runConcretePlayback',
+		async (harnessArgs) => {
+			callConcretePlayback('Kani.runConcretePlayback', harnessArgs);
+		},
+	);
+
 	// Callback function to Find or create files, update test tree and present to user upon trigger
 	async function updateNodeForDocument(e: vscode.TextDocument): Promise<void> {
 		if (e.uri.scheme !== 'file') {
@@ -224,4 +232,5 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(runKani);
 	context.subscriptions.push(runcargoKani);
 	context.subscriptions.push(runningViewerReport);
+	context.subscriptions.push(runningConcretePlayback);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import {
 	getWorkspaceTestPatterns,
 	testData,
 } from './test-tree/createTests';
+import { callConcretePlayback } from './ui/concrete-playback/concretePlayback';
 import { callViewerReport } from './ui/reportView/callReport';
 import { showInformationMessage } from './ui/showMessage';
 import { SourceCodeParser } from './ui/sourceCodeParser';

--- a/src/test-tree/createTests.ts
+++ b/src/test-tree/createTests.ts
@@ -364,7 +364,7 @@ class FailedCase extends TestCase {
 			`command:Kani.runConcretePlayback?${encodeURIComponent(JSON.stringify(args))}`,
 		);
 		sample.appendMarkdown(
-			`[Run Concrete Playback for ${this.harness_name}](${concretePlaybackUri})`,
+			`[Run concrete playback for ${this.harness_name}](${concretePlaybackUri})`,
 		);
 
 		return sample;

--- a/src/test-tree/createTests.ts
+++ b/src/test-tree/createTests.ts
@@ -325,7 +325,8 @@ class FailedCase extends TestCase {
 	}
 
 	handleFailure(): TestMessage {
-		const finalFailureMessage: MarkdownString = this.appendLink(this.failed_checks);
+		const failureMessage: MarkdownString = this.appendLink(this.failed_checks);
+		const finalFailureMessage: MarkdownString = this.appendConcretePlaybackLink(failureMessage);
 		const messageWithLink = new TestMessage(finalFailureMessage);
 		return messageWithLink;
 	}
@@ -349,6 +350,26 @@ class FailedCase extends TestCase {
 		return sample;
 	}
 
+	// Add link and present to the user as the diff message
+	appendConcretePlaybackLink(sample: MarkdownString): MarkdownString {
+		sample.appendMarkdown('<br>');
+		const args = [
+			{
+				harnessName: this.harness_name,
+				harnessFile: this.file_name,
+				harnessType: this.harness_type,
+			},
+		];
+		const concretePlaybackUri: Uri = Uri.parse(
+			`command:Kani.runConcretePlayback?${encodeURIComponent(JSON.stringify(args))}`,
+		);
+		sample.appendMarkdown(
+			`[Run Concrete Playback for ${this.harness_name}](${concretePlaybackUri})`,
+		);
+
+		return sample;
+	}
+
 	// create the failure ui in markdown text with link
 	makeMarkdown(failedChecks: string): MarkdownString {
 		const placeholderMarkdown: vscode.MarkdownString = new vscode.MarkdownString('', true);
@@ -359,7 +380,7 @@ class FailedCase extends TestCase {
 			return placeholderMarkdown;
 		}
 
-		const lines = failedChecks.split('\n');
+		const lines: string[] = failedChecks.split('\n');
 
 		for (const line of lines) {
 			placeholderMarkdown.appendMarkdown(line);

--- a/src/test-tree/createTests.ts
+++ b/src/test-tree/createTests.ts
@@ -357,7 +357,7 @@ class FailedCase extends TestCase {
 			{
 				harnessName: this.harness_name,
 				harnessFile: this.file_name,
-				harnessType: this.harness_type,
+				harnessType: this.proof_boolean,
 			},
 		];
 		const concretePlaybackUri: Uri = Uri.parse(

--- a/src/ui/concrete-playback/concretePlayback.ts
+++ b/src/ui/concrete-playback/concretePlayback.ts
@@ -1,3 +1,5 @@
+// Copyright Kani Contributors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 import process = require('process');
 
 import * as vscode from 'vscode';

--- a/src/ui/concrete-playback/concretePlayback.ts
+++ b/src/ui/concrete-playback/concretePlayback.ts
@@ -47,15 +47,12 @@ function createCommand(
 ): string {
 	// Check if cargo toml exists
 	const isCargo = checkCargoExist();
-	let finalCommand: string = '';
 	const command: string = commandURI === 'Kani.runConcretePlayback' ? 'kani' : 'cargo kani';
 
-	if(!isCargo || harnessType) {
-		finalCommand = `${command} ${harnessFile} --harness ${harnessName} --enable-unstable --concrete-playback=inplace`;
-	}
-	else {
-		finalCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName}`;
+	if (!isCargo || harnessType) {
+		return `${command} ${harnessFile} --harness ${harnessName} --enable-unstable --concrete-playback=inplace`;
+	} else {
+		return `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName}`;
 	}
 
-	return finalCommand;
 }

--- a/src/ui/concrete-playback/concretePlayback.ts
+++ b/src/ui/concrete-playback/concretePlayback.ts
@@ -1,0 +1,63 @@
+import process = require('process');
+
+import * as vscode from 'vscode';
+
+import { KaniArguments, KaniConstants } from '../../constants';
+import { checkCargoExist, getRootDir } from '../../utils';
+
+/**
+ * Call the visualize flag on the harness and render the html page
+ *
+ * @param commandURI - vscode command that is being executed
+ * @param harnessObj - metadata about the harness
+ */
+export async function callConcretePlayback(
+	commandURI: string,
+	harnessObj: { harnessName: string; harnessFile: string; harnessType: boolean },
+): Promise<void> {
+	let finalCommand: string = '';
+
+	const platform: NodeJS.Platform = process.platform;
+	const harnessName: string = harnessObj.harnessName;
+	const harnessFile: string = harnessObj.harnessFile;
+	const harnessType: boolean = harnessObj.harnessType;
+
+	// Detect source file
+	const terminal = vscode.window.activeTerminal ?? vscode.window.createTerminal();
+
+	// Generate the final visualize command for the supported platforms
+	if (platform === 'darwin' || platform == 'linux') {
+		const responseObject: string = createCommand(commandURI, harnessFile, harnessName, harnessType);
+		const crateURI: string = getRootDir();
+		finalCommand = `cd ${crateURI} && ${responseObject}`;
+	}
+
+	// Wait for the the visualize command to finish generating the report
+	terminal.sendText(finalCommand);
+}
+
+// Check if cargo toml exists and create corresponding kani command
+function createCommand(
+	commandURI: string,
+	harnessFile: string,
+	harnessName: string,
+	harnessType: boolean,
+): string {
+	// Check if cargo toml exists
+	const isCargo = checkCargoExist();
+	let finalCommand: string = '';
+
+	if (!isCargo) {
+		const command: string = commandURI === 'Kani.runConcretePlayback' ? 'kani' : 'cargo kani';
+		finalCommand = `${command} ${harnessFile} --harness ${harnessName} --enable-unstable --concrete-playback=inplace`;
+	} else {
+		if (harnessType) {
+			const command: string = commandURI === 'Kani.runConcretePlayback' ? 'kani' : 'cargo kani';
+			finalCommand = `${command} ${harnessFile} --harness ${harnessName} --enable-unstable --concrete-playback=inplace`;
+		} else {
+			finalCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName} --visualize`;
+		}
+	}
+
+	return finalCommand;
+}

--- a/src/ui/concrete-playback/concretePlayback.ts
+++ b/src/ui/concrete-playback/concretePlayback.ts
@@ -48,17 +48,13 @@ function createCommand(
 	// Check if cargo toml exists
 	const isCargo = checkCargoExist();
 	let finalCommand: string = '';
+	const command: string = commandURI === 'Kani.runConcretePlayback' ? 'kani' : 'cargo kani';
 
-	if (!isCargo) {
-		const command: string = commandURI === 'Kani.runConcretePlayback' ? 'kani' : 'cargo kani';
+	if(!isCargo || harnessType) {
 		finalCommand = `${command} ${harnessFile} --harness ${harnessName} --enable-unstable --concrete-playback=inplace`;
-	} else {
-		if (harnessType) {
-			const command: string = commandURI === 'Kani.runConcretePlayback' ? 'kani' : 'cargo kani';
-			finalCommand = `${command} ${harnessFile} --harness ${harnessName} --enable-unstable --concrete-playback=inplace`;
-		} else {
-			finalCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName} --visualize`;
-		}
+	}
+	else {
+		finalCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName}`;
 	}
 
 	return finalCommand;


### PR DESCRIPTION
### Description of changes: 

Adds the button for adding the `concrete_playback` unit test directly into the user's source code.

The button -

![image](https://user-images.githubusercontent.com/91620234/234144370-2a6f756a-d49c-4fb4-bb05-7cb4036ac743.png)

The unit test generated - 

![image](https://user-images.githubusercontent.com/91620234/234144479-7eb9ae2e-9aef-4d6d-a7fb-783df997cddb.png)

### Resolved issues:

Resolves half of #52 

### Call-outs:

1. This does not allow Kani to run the unit test yet. The action for that will be addressed in a coming PR.
2. The unit tests generated by clicking on the button cannot be run with the regular `cargo test` invocation. The full invocation looks something like this - `RUSTFLAGS="--cfg=kani" cargo +nightly test`.
3. Not tested end to end, but runs reliably under manual testing as it uses the terminal to execute instead of spawning an entire process.

### Testing:

* How is this change tested? Manual testing under various scenarios.

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
