### PR TITLE
Removes redundant re-running of kani process 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/model-checking/kani-vscode-extension"
   },
-  "version": "0.0.2",
+  "version": "0.0.4",
   "engines": {
     "vscode": "^1.70.0"
   },

--- a/src/model/kaniCommandCreate.ts
+++ b/src/model/kaniCommandCreate.ts
@@ -21,14 +21,16 @@ export async function runKaniHarnessInterface(harnessName: string, args?: number
 		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
 	}
 	const kaniOutput = await catchOutput(harnessCommand);
-	if( typeof kaniOutput == "number") {
+	if (typeof kaniOutput == 'number') {
 		return [kaniOutput, ''];
-	}
-	else if( Array.isArray(kaniOutput) && kaniOutput.length == 2 && typeof kaniOutput[0] === "number" && typeof kaniOutput[1] === "object")
-	{
+	} else if (
+		Array.isArray(kaniOutput) &&
+		kaniOutput.length == 2 &&
+		typeof kaniOutput[0] === 'number' &&
+		typeof kaniOutput[1] === 'object'
+	) {
 		return kaniOutput;
-	}
-	else {
+	} else {
 		return [5, ''];
 	}
 }

--- a/src/model/kaniCommandCreate.ts
+++ b/src/model/kaniCommandCreate.ts
@@ -21,7 +21,16 @@ export async function runKaniHarnessInterface(harnessName: string, args?: number
 		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
 	}
 	const kaniOutput = await catchOutput(harnessCommand);
-	return kaniOutput;
+	if( typeof kaniOutput == "number") {
+		return [kaniOutput, ''];
+	}
+	else if( Array.isArray(kaniOutput) && kaniOutput.length == 2 && typeof kaniOutput[0] === "number" && typeof kaniOutput[1] === "object")
+	{
+		return kaniOutput;
+	}
+	else {
+		return [5, ''];
+	}
 }
 
 /**
@@ -97,7 +106,7 @@ export async function runCommandPure(command: string): Promise<void> {
 }
 
 // Run a command and capture the command line output into a string
-async function catchOutput(command: string, cargoKaniMode: boolean = false): Promise<number> {
+async function catchOutput(command: string, cargoKaniMode: boolean = false): Promise<any> {
 	const process = await runKaniCommand(command);
 	return process;
 }

--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -153,8 +153,7 @@ function executeKaniProcess(
 					if (stdout) {
 						const responseObject: KaniResponse = responseParserInterface(stdout.toString('utf-8'));
 						resolve([1, responseObject]);
-					}
-					else {
+					} else {
 						resolve(1);
 					}
 				} else {

--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -150,7 +150,13 @@ function executeKaniProcess(
 			} else if (error) {
 				if (error.code === 1) {
 					// verification failed
-					resolve(1);
+					if (stdout) {
+						const responseObject: KaniResponse = responseParserInterface(stdout.toString('utf-8'));
+						resolve([1, responseObject]);
+					}
+					else {
+						resolve(1);
+					}
 				} else {
 					// Error is an object created by nodejs created when nodejs cannot execute the command
 					vscode.window.showErrorMessage(

--- a/src/test-tree/createTests.ts
+++ b/src/test-tree/createTests.ts
@@ -226,7 +226,7 @@ export class TestCase {
 			} else {
 				const responseObject: KaniResponse | string = actualResult[1];
 
-				if(typeof responseObject == 'string') {
+				if (typeof responseObject == 'string') {
 					return;
 				}
 
@@ -275,7 +275,11 @@ export class TestCase {
 	}
 
 	// Run kani on the file, crate with given arguments
-	async evaluate(rsFile: string, harness_name: string, args?: number): Promise<[number, KaniResponse | string]> {
+	async evaluate(
+		rsFile: string,
+		harness_name: string,
+		args?: number,
+	): Promise<[number, KaniResponse | string]> {
 		if (vscode.workspace.workspaceFolders !== undefined) {
 			if (args === undefined || NaN) {
 				const outputKani: any = await runKaniHarnessInterface(harness_name);


### PR DESCRIPTION
### Description of changes: 

The extension's process for running Kani runs Kani twice (for cases where there's a failure). Once for getting the overall verification result, and then for getting the output of Kani. Now, the process does not re-run for failed cases and simply returns the output and the result at the same time. 

### Resolved issues:

Resolves #43

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
