### PR TITLE
Add an error-handling dialogue that links to bug reports

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,12 +21,12 @@ import { callViewerReport } from './ui/reportView/callReport';
 import { showInformationMessage } from './ui/showMessage';
 import { SourceCodeParser } from './ui/sourceCodeParser';
 import { startWatchingWorkspace } from './ui/watchWorkspace';
-import { checkCargoExist, getContentFromFilesystem, getRootDirURI } from './utils';
+import { checkCargoExist, getContentFromFilesystem, getRootDirURI, showErrorWithReportIssueButton } from './utils';
 
 // Entry point of the extension
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
 	if (!checkCargoExist()) {
-		vscode.window.showErrorMessage('Cannot find Cargo.toml to run Cargo Kani on crate');
+		showErrorWithReportIssueButton('Cannot find Cargo.toml to run Cargo Kani on crate');
 	}
 
 	const controller: vscode.TestController = vscode.tests.createTestController(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,12 @@ import { callViewerReport } from './ui/reportView/callReport';
 import { showInformationMessage } from './ui/showMessage';
 import { SourceCodeParser } from './ui/sourceCodeParser';
 import { startWatchingWorkspace } from './ui/watchWorkspace';
-import { checkCargoExist, getContentFromFilesystem, getRootDirURI, showErrorWithReportIssueButton } from './utils';
+import {
+	checkCargoExist,
+	getContentFromFilesystem,
+	getRootDirURI,
+	showErrorWithReportIssueButton,
+} from './utils';
 
 // Entry point of the extension
 export async function activate(context: vscode.ExtensionContext): Promise<void> {

--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import { KaniResponse } from '../constants';
-import { CommandArgs, getRootDir, splitCommand } from '../utils';
+import { CommandArgs, getRootDir, showErrorWithReportIssueButton, splitCommand } from '../utils';
 import { responseParserInterface } from './kaniOutputParser';
 
 /**
@@ -112,7 +112,7 @@ export async function createFailedDiffMessage(command: string): Promise<KaniResp
 		});
 	} else {
 		// Error Case
-		vscode.window.showWarningMessage('Kani executable crashed while parsing error message');
+		showErrorWithReportIssueButton('Kani executable crashed while parsing error message');
 		return new Promise((resolve, _reject) => {
 			resolve({ failedProperty: 'error', failedMessages: 'error' });
 		});
@@ -140,7 +140,7 @@ function executeKaniProcess(
 				if (cargoKaniMode) {
 					// stderr is an output stream that happens when there are no problems executing the kani command but kani itself throws an error due to (most likely)
 					// a rustc error or an unhandled kani error
-					vscode.window.showErrorMessage(
+					showErrorWithReportIssueButton(
 						`Kani Executable Crashed due to an underlying rustc error ->\n ${stderr}`,
 					);
 					reject();
@@ -153,7 +153,7 @@ function executeKaniProcess(
 					resolve(1);
 				} else {
 					// Error is an object created by nodejs created when nodejs cannot execute the command
-					vscode.window.showErrorMessage(
+					showErrorWithReportIssueButton(
 						`Kani Extension could not execute command due to error ->\n ${error}`,
 					);
 					reject();

--- a/src/ui/reportView/callReport.ts
+++ b/src/ui/reportView/callReport.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 
 import { KaniArguments, KaniConstants } from '../../constants';
 import { getKaniPath } from '../../model/kaniRunner';
-import { CommandArgs, checkCargoExist, getRootDir, splitCommand } from '../../utils';
+import { CommandArgs, checkCargoExist, getRootDir, showErrorWithReportIssueButton, splitCommand } from '../../utils';
 
 const { execFile } = require('child_process');
 const { promisify } = require('util');
@@ -79,13 +79,13 @@ function showVisualizeError(output: reportMetadata): void {
 	switch (output.statusCode) {
 		// Could not run the visualize command
 		case 1:
-			vscode.window.showErrorMessage(
+			showErrorWithReportIssueButton(
 				`Could not generate report due to execution error: ${output.error}`,
 			);
 			break;
 		// Could run the command, but the file generated could not be verified or was generated at wrong location
 		case 2:
-			vscode.window.showErrorMessage(`Could not find path to the report file: ${output.error}`);
+			showErrorWithReportIssueButton(`Could not find path to the report file: ${output.error}`);
 			break;
 	}
 	return;

--- a/src/ui/reportView/callReport.ts
+++ b/src/ui/reportView/callReport.ts
@@ -8,7 +8,13 @@ import * as vscode from 'vscode';
 
 import { KaniArguments, KaniConstants } from '../../constants';
 import { getKaniPath } from '../../model/kaniRunner';
-import { CommandArgs, checkCargoExist, getRootDir, showErrorWithReportIssueButton, splitCommand } from '../../utils';
+import {
+	CommandArgs,
+	checkCargoExist,
+	getRootDir,
+	showErrorWithReportIssueButton,
+	splitCommand,
+} from '../../utils';
 
 const { execFile } = require('child_process');
 const { promisify } = require('util');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,13 +4,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { TextDecoder } from 'util';
 
-
-
 import * as toml from 'toml';
 import * as vscode from 'vscode';
 
 const textDecoder = new TextDecoder('utf-8');
-const linkToBugReportTemplate = 'https://github.com/model-checking/kani-vscode-extension/issues/new?assignees=&labels=bug&projects=&template=bug_report.md'
+const linkToBugReportTemplate =
+	'https://github.com/model-checking/kani-vscode-extension/issues/new?assignees=&labels=bug&projects=&template=bug_report.md';
 
 export interface CommandArgs {
 	commandPath: string;


### PR DESCRIPTION
### Description of changes: 

This PR adds a new function that shows an error message with a button that links to the [bug report template webpage](https://github.com/model-checking/kani-vscode-extension/issues/new?assignees=&labels=bug&projects=&template=bug_report.md). It also replaces all current error messages with this one, so users have an easy way to report extension-related bugs to this repository.

The error message/dialogue looks like this:

![Screen Shot 2023-05-15 at 15 19 32](https://github.com/model-checking/kani-vscode-extension/assets/73246657/5bc76f82-ab4d-4ef1-a3cb-98f76f56effb)

### Resolved issues:

Resolves #75 

### Call-outs:

Tested changes locally by removing the `--enable-unstable` option from the visualize arguments. I didn't know of a better way to trigger an error (other than uninstalling `cargo`, which is too much IMHO).
<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? See **"call-outs"**.

* Is this a refactor change? No.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
