### PR TITLE
Add output log to channel

### DIFF
--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -196,7 +196,7 @@ function sendOutputToChannel(output: CommandOutput, args: string[]): void {
 
 	// Create unique ID for the output channel
 	const timestamp = getTimeBasedUniqueId();
-	const channel = vscode.window.createOutputChannel(`Kani Output ${harnessName} - ${timestamp}`);
+	const channel = vscode.window.createOutputChannel(`Output (Kani): ${harnessName} - ${timestamp}`);
 
 	// Append stdout to the output channel
 	channel.appendLine(output.stdout);

--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -7,17 +7,21 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import { KaniResponse } from '../constants';
-import { CommandArgs, getRootDir,getTimeBasedUniqueId, showErrorWithReportIssueButton, splitCommand } from '../utils';
+import {
+	CommandArgs,
+	getRootDir,
+	getTimeBasedUniqueId,
+	showErrorWithReportIssueButton,
+	splitCommand,
+} from '../utils';
 import { responseParserInterface } from './kaniOutputParser';
-
 
 interface CommandOutput {
 	stdout: string;
 	stderr: string;
 	errorCode: number | undefined;
-	error: any
-  }
-
+	error: any;
+}
 
 /**
  * Get the system resolved path to the cargo-kani command
@@ -145,13 +149,11 @@ function executeKaniProcess(
 ): Promise<any> {
 	return new Promise((resolve, reject) => {
 		execFile(kaniBinaryPath, args, options, (error, stdout, stderr) => {
-
-
 			const output: CommandOutput = {
 				stdout: stdout.toString().trim(),
 				stderr: stderr.toString().trim(),
 				errorCode: error?.code,
-				error: error
+				error: error,
 			};
 
 			// Call the process function with the output

--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -16,6 +16,7 @@ import {
 } from '../utils';
 import { responseParserInterface } from './kaniOutputParser';
 
+// Store the output from process into a object with this type
 interface CommandOutput {
 	stdout: string;
 	stderr: string;
@@ -149,6 +150,7 @@ function executeKaniProcess(
 ): Promise<any> {
 	return new Promise((resolve, reject) => {
 		execFile(kaniBinaryPath, args, options, (error, stdout, stderr) => {
+			// Store the output of the process into an object
 			const output: CommandOutput = {
 				stdout: stdout.toString().trim(),
 				stderr: stderr.toString().trim(),
@@ -156,7 +158,7 @@ function executeKaniProcess(
 				error: error,
 			};
 
-			// Call the process function with the output
+			// Send output to output channel specific to the harness
 			sendOutputToChannel(output, args);
 
 			if (stderr && !stdout) {

--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -190,6 +190,7 @@ function executeKaniProcess(
 	});
 }
 
+// Creates a unique name and adds a channel for the harness output to Output Logs
 function sendOutputToChannel(output: CommandOutput, args: string[]): void {
 	const harnessName = args.at(1)!;
 

--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -152,8 +152,8 @@ function executeKaniProcess(
 		execFile(kaniBinaryPath, args, options, (error, stdout, stderr) => {
 			// Store the output of the process into an object
 			const output: CommandOutput = {
-				stdout: stdout.toString().trim(),
-				stderr: stderr.toString().trim(),
+				stdout: stdout.toString(),
+				stderr: stderr.toString(),
 				errorCode: error?.code,
 				error: error,
 			};

--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import { KaniResponse } from '../constants';
-import { CommandArgs, getRootDir, splitCommand } from '../utils';
+import { CommandArgs, getRootDir, getTimeBasedUniqueId, splitCommand } from '../utils';
 import { responseParserInterface } from './kaniOutputParser';
 
 
@@ -155,7 +155,7 @@ function executeKaniProcess(
 			};
 
 			// Call the process function with the output
-			processOutput(output, args);
+			sendOutputToChannel(output, args);
 
 			if (stderr && !stdout) {
 				if (cargoKaniMode) {
@@ -170,7 +170,6 @@ function executeKaniProcess(
 				}
 			} else if (error) {
 				if (error.code === 1) {
-					// verification failed
 					resolve(1);
 				} else {
 					// Error is an object created by nodejs created when nodejs cannot execute the command
@@ -187,14 +186,13 @@ function executeKaniProcess(
 	});
 }
 
-
-function processOutput(output: CommandOutput, args: string[]): void {
+function sendOutputToChannel(output: CommandOutput, args: string[]): void {
 	const harnessName = args.at(1)!;
-	const channel = vscode.window.createOutputChannel(`Kani Output ${harnessName}`);
 
-	// Add output
-	console.log(output);
+	// Create unique ID for the output channel
+	const timestamp = getTimeBasedUniqueId();
+	const channel = vscode.window.createOutputChannel(`Kani Output ${harnessName} - ${timestamp}`);
 
-	// Append stdout and stderr to the output channel
+	// Append stdout to the output channel
 	channel.appendLine(output.stdout);
-  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,6 +126,13 @@ export async function getPackageName(): Promise<any> {
 	}
 }
 
+// Create a timestamp to help differentiate strings
+export function getTimeBasedUniqueId(): string {
+	const timestamp = new Date().getTime().toString();
+	return timestamp;
+}
+
+
 /* Split the command line invocation into the kani call and the argument array
 For example - Input: '"my command" --arg1 "file with spaces.txt"';
 Output: ['my command', '--arg1', 'file with spaces.txt']

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -134,7 +134,6 @@ export function getTimeBasedUniqueId(): string {
 	return timestamp;
 }
 
-
 /* Split the command line invocation into the kani call and the argument array
 For example - Input: '"my command" --arg1 "file with spaces.txt"';
 Output: ['my command', '--arg1', 'file with spaces.txt']


### PR DESCRIPTION
### Description of changes: 

Sends the stdout to the output channel allowing users to view the full output if they want to.

This is what the output channel looks like - 

<img width="1552" alt="Screen Shot 2023-05-15 at 3 55 12 PM" src="https://github.com/model-checking/kani-vscode-extension/assets/91620234/4197d412-226b-4115-a500-7065bfdfe8f5">

### Resolved issues:

Resolves #67 

### Testing:

* How is this change tested? Manual

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
