### PR TITLE
Emit an error if Kani executable was not found

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,14 +34,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	if (!checkCargoExist()) {
 		showErrorWithReportIssueButton('Cannot find Cargo.toml to run Cargo Kani on crate');
 	}
-	getKaniPath('cargo-kani').catch((error) => {
+	try {
+		// GET binary path
+		const kaniBinaryPath = await getKaniPath('cargo-kani');
+	} catch (error) {
 		showErrorWithReportIssueButton(
-			'The Kani executable was not found in PATH. Please install it using the instructions at https://model-checking.github.io/kani/install-guide.html and/or make sure it is in your PATH.',
+			'The Kani executable was not found in PATH. Please install it using the instructions         at https://model-checking.github.io/kani/install-guide.html and/or make sure it is in your PATH.',
 		);
-		return new Promise((resolve, reject) => {
-			reject(new Error(`Failed to launch Kani extension`));
-		});
-	});
+		return;
+	}
 
 	const controller: vscode.TestController = vscode.tests.createTestController(
 		'Kani Proofs',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,8 +4,8 @@ import * as vscode from 'vscode';
 import { Uri } from 'vscode';
 
 import { connectToDebugger } from './debugger/debugger';
-import { runCargoTest } from './model/runCargoTest';
 import { getKaniPath } from './model/kaniRunner';
+import { runCargoTest } from './model/runCargoTest';
 import { gatherTestItems } from './test-tree/buildTree';
 import {
 	KaniData,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { Uri } from 'vscode';
 
 import { connectToDebugger } from './debugger/debugger';
 import { runCargoTest } from './model/runCargoTest';
+import { getKaniPath } from './model/kaniRunner';
 import { gatherTestItems } from './test-tree/buildTree';
 import {
 	KaniData,
@@ -33,6 +34,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	if (!checkCargoExist()) {
 		showErrorWithReportIssueButton('Cannot find Cargo.toml to run Cargo Kani on crate');
 	}
+	getKaniPath('cargo-kani').catch((error) => {
+		showErrorWithReportIssueButton(
+			'The Kani executable was not found in PATH. Please install it using the instructions at https://model-checking.github.io/kani/install-guide.html and/or make sure it is in your PATH.',
+		);
+		return new Promise((resolve, reject) => {
+			reject(new Error(`Failed to launch Kani extension`));
+		});
+	});
 
 	const controller: vscode.TestController = vscode.tests.createTestController(
 		'Kani Proofs',

--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -39,6 +39,7 @@ export function getKaniPath(kaniCommand: string): Promise<string> {
 		execFile('which', [kaniCommand], options, (error, stdout, stderr) => {
 			if (error) {
 				console.error(`execFile error: ${error}`);
+				reject(new Error(`Kani executable was not found in PATH.`));
 				return;
 			}
 			if (stderr) {


### PR DESCRIPTION
### Description of changes: 

Check if `which cargo-kani` returned an error, abort execution, and set the test result as "errored". This is what gets shown in VSCode:

![image](https://github.com/model-checking/kani-vscode-extension/assets/88045115/eac35344-b1e1-41da-9d1f-42e3333871fb)

### Resolved issues:

Resolves #72 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

A cleaner approach would be to check on load if Kani is installed, and if not put the extension in an error state and prevent running any harnesses.

### Testing:

* How is this change tested? Removed kani from path, launched extension, and ran one of the harnesses.

* Is this a refactor change?

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
