### PR TITLE
Add awaits to async files and add reload on save

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,10 +129,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	 */
 	controller.refreshHandler = async (): Promise<void> => {
 		await Promise.all(
-			getWorkspaceTestPatterns().map(({ pattern }) => findInitialFiles(controller, pattern)),
+			getWorkspaceTestPatterns().map(async ({ pattern }) => await findInitialFiles(controller, pattern)),
 		);
 		for (const document of vscode.workspace.textDocuments) {
-			updateNodeForDocument(document);
+			await updateNodeForDocument(document);
 		}
 	};
 
@@ -195,7 +195,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		}
 
 		const { file, data } = getOrCreateFile(controller, e.uri);
-		data.updateFromContents(controller, e.getText(), file);
+		await data.updateFromContents(controller, e.getText(), file);
 		data.addToCrate(controller, file, treeRoot);
 	}
 
@@ -225,8 +225,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 	// Update the test tree with proofs whenever a test case is opened
 	context.subscriptions.push(
-		vscode.workspace.onDidOpenTextDocument(updateNodeForDocument),
-		// vscode.workspace.onDidChangeTextDocument(e => updateNodeForDocument(e.document)),
+		vscode.workspace.onDidOpenTextDocument(await updateNodeForDocument),
+		vscode.workspace.onDidSaveTextDocument(async e => await updateNodeForDocument(e)),
 	);
 
 	context.subscriptions.push(runKani);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,7 +129,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	 */
 	controller.refreshHandler = async (): Promise<void> => {
 		await Promise.all(
-			getWorkspaceTestPatterns().map(async ({ pattern }) => await findInitialFiles(controller, pattern)),
+			getWorkspaceTestPatterns().map(({ pattern }) => findInitialFiles(controller, pattern)),
 		);
 		for (const document of vscode.workspace.textDocuments) {
 			await updateNodeForDocument(document);
@@ -225,8 +225,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 	// Update the test tree with proofs whenever a test case is opened
 	context.subscriptions.push(
-		vscode.workspace.onDidOpenTextDocument(await updateNodeForDocument),
-		vscode.workspace.onDidSaveTextDocument(async e => await updateNodeForDocument(e)),
+		vscode.workspace.onDidOpenTextDocument(updateNodeForDocument),
+		vscode.workspace.onDidSaveTextDocument(async (e) => await updateNodeForDocument(e)),
 	);
 
 	context.subscriptions.push(runKani);


### PR DESCRIPTION
### Description of changes: 

1. Adds reload on save that caused tree-sitter changes from not being reflected.
2. Adds await to async fn calls, no real impact to the user.

### Resolved issues:

Resolves #56 

### Testing:

* How is this change tested? Manual

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
