### PR TITLE
Run each Kani harness on specified packages

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,7 @@ export namespace KaniConstants {
 }
 
 export namespace KaniArguments {
+	export const packageFlag: string = `-p`;
 	export const unwindFlag: string = `--unwind`;
 	export const harnessFlag: string = `--harness`;
 	export const testsFlag: string = `--tests`;

--- a/src/debugger/debugger.ts
+++ b/src/debugger/debugger.ts
@@ -12,7 +12,7 @@ import { getPackageName, getRootDir, getRootDirURI } from '../utils';
 async function getBinaryPath(): Promise<string | undefined> {
 	try {
 		// Run 'cargo' command to get the binary path
-		const cargoPath = await getPackageName();
+		const cargoPath = await getPackageName(getRootDir());
 		const directory = path.resolve(getRootDir());
 		const options = {
 			shell: false,

--- a/src/model/kaniCommandCreate.ts
+++ b/src/model/kaniCommandCreate.ts
@@ -13,12 +13,16 @@ import { createFailedDiffMessage, runKaniCommand } from './kaniRunner';
  * @param args - arguments to Kani if provided
  * @returns verification status (i.e success or failure)
  */
-export async function runKaniHarnessInterface(harnessName: string, args?: number): Promise<any> {
+export async function runKaniHarnessInterface(
+	harnessName: string,
+	packageName: string,
+	args?: number,
+): Promise<any> {
 	let harnessCommand = '';
 	if (args === undefined || isNaN(args)) {
-		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.harnessFlag} ${harnessName}`;
+		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.harnessFlag} ${harnessName}`;
 	} else {
-		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
+		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
 	}
 	const kaniOutput = await catchOutput(harnessCommand);
 	return kaniOutput;
@@ -35,14 +39,15 @@ export async function runKaniHarnessInterface(harnessName: string, args?: number
  */
 export async function runCargoKaniTest(
 	harnessName: string,
+	packageName: string,
 	failedCheck?: boolean,
 	args?: number,
 ): Promise<any> {
 	let harnessCommand = '';
 	if (args === undefined || isNaN(args)) {
-		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName}`;
+		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName}`;
 	} else {
-		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
+		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
 	}
 	if (failedCheck) {
 		const kaniOutput: KaniResponse = await createFailedDiffMessage(harnessCommand);

--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -173,7 +173,8 @@ async function executeKaniProcess(
 			// Send output to diagnostics and return if there is an error in stdout
 			// this means that the command could not be executed.
 			if (checkOutputForError(output.stdout, output.stderr)) {
-				reject(new Error(stdout.toString('utf-8')));
+				sendErrorToChannel(output, args);
+				reject(new Error(error?.message));
 			}
 
 			// Send output to output channel specific to the harness
@@ -206,6 +207,18 @@ async function executeKaniProcess(
 			}
 		});
 	});
+}
+
+// Creates a unique name and adds a channel for the harness output to Output Logs
+function sendErrorToChannel(output: CommandOutput, args: string[]): void {
+	const harnessName = args.at(1)!;
+
+	// Create unique ID for the output channel
+	const timestamp = getTimeBasedUniqueId();
+	const channel = vscode.window.createOutputChannel(`Error: ${harnessName} - ${timestamp}`);
+
+	// Append stdout to the output channel
+	channel.appendLine(output.error?.message);
 }
 
 // Creates a unique name and adds a channel for the harness output to Output Logs

--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -20,7 +20,7 @@ import { checkOutputForError, responseParserInterface } from './kaniOutputParser
 interface CommandOutput {
 	stdout: string;
 	stderr: string;
-	errorCode: number | undefined;
+	errorCode: any;
 	error: any;
 }
 

--- a/src/model/runCargoTest.ts
+++ b/src/model/runCargoTest.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 import * as vscode from 'vscode';
 
-import { getPackageName } from '../utils';
+import { getPackageName, getRootDir } from '../utils';
 
 /**
  * Runs the cargo test task whenever the user clicks on a codelens button
@@ -11,7 +11,7 @@ import { getPackageName } from '../utils';
 export async function runCargoTest(functionName: string): Promise<void> {
 	const taskName = `Cargo Test: ${functionName}`;
 
-	const packageName = await getPackageName();
+	const packageName = await getPackageName(getRootDir());
 	const taskDefinition: vscode.TaskDefinition = {
 		type: 'cargo',
 		command: 'test',

--- a/src/ui/sourceCodeParser.ts
+++ b/src/ui/sourceCodeParser.ts
@@ -95,7 +95,7 @@ export namespace SourceCodeParser {
 						);
 						const unprocessedLine = strList[j].text.split('\n')[0];
 						const current_harness: HarnessMetadata = {
-							name: functionName.text,
+							harnessName: functionName.text,
 							fullLine: unprocessedLine,
 							endPosition: functionName.endPosition,
 							attributes: attributesMetadata,
@@ -204,7 +204,7 @@ export namespace SourceCodeParser {
 				if (harness) {
 					assert.equal(harness.fullLine, line.trim());
 
-					const name: string = harness.name;
+					const name: string = harness.harnessName;
 					// Range should cover the entire harness
 					const range = new vscode.Range(
 						new vscode.Position(lineNo, 0),

--- a/src/ui/sourceMap.ts
+++ b/src/ui/sourceMap.ts
@@ -1,15 +1,21 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-export interface FileMetaData {
-	fileName: string;
-	filePath: string;
-	crateName: string;
-	cratePath: string;
+
+export interface FileHarnessMetaData {
+	fileMetaData: FileMetaData[];
 	harnesses: HarnessMetadata[];
 }
 
+export interface FileMetaData {
+	fileName: string;
+	filePath: string;
+	filePackage: string;
+	crateName: string;
+	cratePath: string;
+}
+
 export interface HarnessMetadata {
-	name: string;
+	harnessName: string;
 	fullLine: string;
 	endPosition: Position;
 	attributes: string[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,14 +113,12 @@ export function extractFunctionName(line: string): string {
 }
 
 // Get the package name for the workspace from cargo.toml
-export async function getPackageName(): Promise<any> {
-	const dirName = getRootDir();
+export async function getPackageName(dirName: string): Promise<any> {
 	const cargoTomlUri = vscode.Uri.file(`${dirName}/Cargo.toml`);
 
 	try {
-		const buffer = await vscode.workspace.fs.readFile(cargoTomlUri);
-		const cargoToml = buffer.toString();
-		const cargoTomlObject = toml.parse(cargoToml);
+		const tomlFile = await vscode.workspace.fs.readFile(cargoTomlUri);
+		const cargoTomlObject = toml.parse(tomlFile.toString());
 		return cargoTomlObject.package?.name;
 	} catch (error) {
 		console.error(error);


### PR DESCRIPTION
### Description of changes: 

The extension don't need to compile an entire project to run every single harness in this project. Now, it takes into account the package information and only runs Kani on the specified packages for each harness. This will allow us to run the extension even in projects that may have constructs that are not fully supported by Kani, as well as improve compilation time.

This PR also improves:
 - `FileMetaData` to collect more information about each harness. This info can latter be used to improve debug information;
 - Error report for the user;


### Resolved issues:

N/A.

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
