### PR TITLE
Replace unwind arguments with stubbing arguments

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,4 +16,6 @@ export namespace KaniArguments {
 	export const harnessFlag: string = `--harness`;
 	export const testsFlag: string = `--tests`;
 	export const outputFormatFlag: string = `--output-format`;
+	export const unstableFormatFlag: string = `--enable-unstable`;
+	export const stubbingFlag: string = `--enable-stubbing`;
 }

--- a/src/model/kaniCommandCreate.ts
+++ b/src/model/kaniCommandCreate.ts
@@ -16,13 +16,13 @@ import { createFailedDiffMessage, runKaniCommand } from './kaniRunner';
 export async function runKaniHarnessInterface(
 	harnessName: string,
 	packageName: string,
-	args?: number,
+	stubbing_args?: boolean,
 ): Promise<any> {
 	let harnessCommand = '';
-	if (args === undefined || isNaN(args)) {
+	if (stubbing_args === undefined || !stubbing_args) {
 		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.harnessFlag} ${harnessName}`;
 	} else {
-		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
+		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.unstableFormatFlag} ${KaniArguments.stubbingFlag} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.harnessFlag} ${harnessName}`;
 	}
 	const kaniOutput = await catchOutput(harnessCommand);
 	return kaniOutput;
@@ -41,10 +41,10 @@ export async function runCargoKaniTest(
 	harnessName: string,
 	packageName: string,
 	failedCheck?: boolean,
-	args?: number,
+	args?: boolean,
 ): Promise<any> {
 	let harnessCommand = '';
-	if (args === undefined || isNaN(args)) {
+	if (args === undefined || !args) {
 		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName}`;
 	} else {
 		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.testsFlag} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;
@@ -69,11 +69,11 @@ export async function runCargoKaniTest(
  */
 export async function captureFailedChecks(
 	harnessName: string,
-	args?: number,
+	args?: boolean,
 ): Promise<KaniResponse> {
 	let harnessCommand = '';
 
-	if (args === undefined || isNaN(args)) {
+	if (args === undefined || !args) {
 		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.harnessFlag} ${harnessName}`;
 	} else {
 		harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.harnessFlag} ${harnessName} ${KaniArguments.unwindFlag} ${args}`;

--- a/src/test-tree/createTests.ts
+++ b/src/test-tree/createTests.ts
@@ -316,7 +316,11 @@ export class TestCase {
 				const outputKani: number = await runKaniHarnessInterface(harness_name, package_name);
 				return outputKani;
 			} else {
-				const outputKani: number = await runKaniHarnessInterface(harness_name, package_name, stubbing);
+				const outputKani: number = await runKaniHarnessInterface(
+					harness_name,
+					package_name,
+					stubbing,
+				);
 				return outputKani;
 			}
 		}

--- a/src/test-tree/createTests.ts
+++ b/src/test-tree/createTests.ts
@@ -336,7 +336,7 @@ export class TestCase {
 		stubbing?: boolean,
 	): Promise<number> {
 		if (vscode.workspace.workspaceFolders !== undefined) {
-			if (stubbing_args === false || undefined || NaN) {
+			if (stubbing === false || undefined || NaN) {
 				const outputKaniTest: number = await runCargoKaniTest(harness_name, package_name, false);
 				return outputKaniTest;
 			} else {
@@ -344,7 +344,7 @@ export class TestCase {
 					harness_name,
 					package_name,
 					false,
-					stubbing_args,
+					stubbing,
 				);
 				return outputKaniTest;
 			}

--- a/src/test-tree/createTests.ts
+++ b/src/test-tree/createTests.ts
@@ -206,7 +206,7 @@ export class TestFile {
  * @param harness_name - name of harness to be verified
  * @param package_name - Name of the package the harness is under that is extracted from cargo.toml
  * @param proof_boolean - True if proof, false if bolero harness
- * @param stubbing_request - True if there's a stub request attribute present
+ * @param stubbing - True if the Kani harness is annotated with stubs
  * @returns verification status (i.e success or failure)
  */
 export class TestCase {
@@ -333,7 +333,7 @@ export class TestCase {
 	async evaluateTest(
 		harness_name: string,
 		package_name: string,
-		stubbing_args?: boolean,
+		stubbing?: boolean,
 	): Promise<number> {
 		if (vscode.workspace.workspaceFolders !== undefined) {
 			if (stubbing_args === false || undefined || NaN) {

--- a/src/test-tree/createTests.ts
+++ b/src/test-tree/createTests.ts
@@ -204,8 +204,9 @@ export class TestFile {
  *
  * @param file_name - name of the harness that is to be verified
  * @param harness_name - name of harness to be verified
+ * @param package_name - Name of the package the harness is under that is extracted from cargo.toml
  * @param proof_boolean - True if proof, false if bolero harness
- * @param harness_unwind_value - unwind value of the harness (if it exists)
+ * @param stubbing_request - True if there's a stub request attribute present
  * @returns verification status (i.e success or failure)
  */
 export class TestCase {

--- a/src/test/test-programs/sampleRustString.ts
+++ b/src/test/test-programs/sampleRustString.ts
@@ -425,7 +425,7 @@ export const attributeMetadataUnsupported = [
 			row: 6,
 			column: 13,
 		},
-		attributes: ["#[kani::unwind(0)]", "#[kani::should_panic]", "#[kani::cover]"],
+		attributes: ['#[kani::unwind(0)]', '#[kani::should_panic]', '#[kani::cover]'],
 		args: {
 			proof: true,
 			test: false,

--- a/src/test/test-programs/sampleRustString.ts
+++ b/src/test/test-programs/sampleRustString.ts
@@ -425,7 +425,7 @@ export const attributeMetadataUnsupported = [
 			row: 6,
 			column: 13,
 		},
-		attributes: ["#[kani::unwind(0)]', '#[kani::should_panic]', '#[kani::cover]"],
+		attributes: ["#[kani::unwind(0)]", "#[kani::should_panic]", "#[kani::cover]"],
 		args: {
 			proof: true,
 			test: false,

--- a/src/test/test-programs/sampleRustString.ts
+++ b/src/test/test-programs/sampleRustString.ts
@@ -5,21 +5,18 @@ export const fullProgramSource = `
 mod test {
     #[test]
     #[cfg_attr(kani, kani::proof, kani::unwind(0))]
-    #[cfg_attr(miri, ignore)] // this test is too expensive for miri
     fn insert_test_80978342() {
         assert!(1==3);
     }
 
     #[test]
     #[cfg_attr(kani, kani::proof, kani::unwind(1))]
-    #[cfg_attr(miri, ignore)] // this test is too expensive for miri
     fn insert_test_2() {
         assert!(1==1);
     }
 
     #[test]
     #[cfg_attr(kani, kani::proof, kani::unwind(1))]
-    #[cfg_attr(miri, ignore)] // this test is too expensive for miri
     fn random_name() {
         assert!(1==2);
     }
@@ -68,21 +65,18 @@ export const boleroProofs = `
 mod test {
     #[test]
     #[cfg_attr(kani, kani::proof, kani::unwind(0))]
-    #[cfg_attr(miri, ignore)] // this test is too expensive for miri
     fn insert_test_80978342() {
         assert!(1==3);
     }
 
     #[test]
     #[cfg_attr(kani, kani::proof, kani::unwind(1))]
-    #[cfg_attr(miri, ignore)] // this test is too expensive for miri
     fn insert_test_2() {
         assert!(1==1);
     }
 
     #[test]
     #[cfg_attr(kani, kani::proof, kani::unwind(1))]
-    #[cfg_attr(miri, ignore)] // this test is too expensive for miri
     fn random_name() {
         assert!(1==2);
     }
@@ -137,12 +131,36 @@ fn function_1() {
     assert!(1 == 2);
 }
 
+#[cfg(kani)]
+fn mock_random<T: kani::Arbitrary>() -> T {
+    kani::any()
+}
 
 #[cfg(kani)]
 #[kani::proof]
-#[kani::stub]
-pub fn function_2() {
-    assert!(1 == 2);
+#[kani::stub(rand::random, mock_random)]
+fn encrypt_then_decrypt_is_identity() {
+    let data: u32 = kani::any();
+    let encryption_key: u32 = rand::random();
+    let encrypted_data = data ^ encryption_key;
+    let decrypted_data = encrypted_data ^ encryption_key;
+    assert_eq!(data, decrypted_data);
+}
+
+#[cfg(kani)]
+#[kani::proof]
+#[kani::stub(rand::random, mock_random)]
+#[kani::unwind(2)]
+#[kani::solver(kissat)]
+#[kani::should_panic]
+fn function_2() {
+    assert_eq!(1, 1);
+}
+
+#[test]
+#[cfg_attr(kani, kani::proof, kani::unwind(1), kani::stub(rand::random, mock_random), kani::solver(kissat))]
+fn function_3() {
+    assert_eq!(1, 1);
 }
 `;
 
@@ -150,19 +168,16 @@ export const rustFileWithoutProof = `
 #[cfg(test)]
 mod test {
     #[test]
-    #[cfg_attr(miri, ignore)] // this test is too expensive for miri
     fn insert_test() {
         assert!(1==2);
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)] // this test is too expensive for miri
     fn insert_test_2() {
         assert!(1==1);
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)] // this test is too expensive for miri
     fn random_name() {
         assert!(1==1);
     }
@@ -171,7 +186,7 @@ mod test {
 
 export const findHarnessesResultKani = [
 	{
-		name: 'function_abc',
+		harnessName: 'function_abc',
 		fullLine: 'fn function_abc() {',
 		endPosition: {
 			row: 4,
@@ -181,10 +196,11 @@ export const findHarnessesResultKani = [
 		args: {
 			proof: true,
 			test: false,
+			stub: false,
 		},
 	},
 	{
-		name: 'function_xyz',
+		harnessName: 'function_xyz',
 		fullLine: 'pub fn function_xyz() {',
 		endPosition: {
 			row: 11,
@@ -194,10 +210,11 @@ export const findHarnessesResultKani = [
 		args: {
 			proof: true,
 			test: false,
+			stub: false,
 		},
 	},
 	{
-		name: 'function_xyz_2',
+		harnessName: 'function_xyz_2',
 		fullLine: 'unsafe fn function_xyz_2() {',
 		endPosition: {
 			row: 20,
@@ -207,10 +224,11 @@ export const findHarnessesResultKani = [
 		args: {
 			proof: true,
 			test: false,
+			stub: false,
 		},
 	},
 	{
-		name: 'function_xyz_3',
+		harnessName: 'function_xyz_3',
 		fullLine: 'pub unsafe fn function_xyz_3() {',
 		endPosition: {
 			row: 26,
@@ -220,10 +238,11 @@ export const findHarnessesResultKani = [
 		args: {
 			proof: true,
 			test: false,
+			stub: false,
 		},
 	},
 	{
-		name: 'function_xyz_7',
+		harnessName: 'function_xyz_7',
 		fullLine: 'fn function_xyz_7() {',
 		endPosition: {
 			row: 34,
@@ -233,184 +252,233 @@ export const findHarnessesResultKani = [
 		args: {
 			proof: true,
 			test: false,
+			stub: false,
 		},
 	},
 ];
 
 export const findHarnessesResultBolero = [
 	{
-		name: 'insert_test_80978342',
+		harnessName: 'insert_test_80978342',
 		fullLine: 'fn insert_test_80978342() {',
 		endPosition: {
-			row: 6,
+			row: 5,
 			column: 27,
 		},
 		attributes: ['#[cfg_attr(kani, kani::proof, kani::unwind(0))]'],
 		args: {
 			proof: true,
 			test: true,
+			stub: false,
 		},
 	},
 	{
-		name: 'insert_test_2',
+		harnessName: 'insert_test_2',
 		fullLine: 'fn insert_test_2() {',
 		endPosition: {
-			row: 13,
+			row: 11,
 			column: 20,
 		},
 		attributes: ['#[cfg_attr(kani, kani::proof, kani::unwind(1))]'],
 		args: {
 			proof: true,
 			test: true,
+			stub: false,
 		},
 	},
 	{
-		name: 'random_name',
+		harnessName: 'random_name',
 		fullLine: 'fn random_name() {',
 		endPosition: {
-			row: 20,
+			row: 17,
 			column: 18,
 		},
 		attributes: ['#[cfg_attr(kani, kani::proof, kani::unwind(1))]'],
 		args: {
 			proof: true,
 			test: true,
+			stub: false,
 		},
 	},
 ];
 
 export const harnessMetadata = [
 	{
-		name: 'insert_test_80978342',
+		harnessName: 'insert_test_80978342',
 		fullLine: 'fn insert_test_80978342() {',
 		endPosition: {
-			row: 6,
+			row: 5,
 			column: 27,
 		},
 		attributes: ['#[cfg_attr(kani, kani::proof, kani::unwind(0))]'],
 		args: {
 			proof: true,
 			test: true,
+			stub: false,
 		},
 	},
 	{
-		name: 'insert_test_2',
+		harnessName: 'insert_test_2',
 		fullLine: 'fn insert_test_2() {',
 		endPosition: {
-			row: 13,
+			row: 11,
 			column: 20,
 		},
 		attributes: ['#[cfg_attr(kani, kani::proof, kani::unwind(1))]'],
 		args: {
 			proof: true,
 			test: true,
+			stub: false,
 		},
 	},
 	{
-		name: 'random_name',
+		harnessName: 'random_name',
 		fullLine: 'fn random_name() {',
 		endPosition: {
-			row: 20,
+			row: 17,
 			column: 18,
 		},
 		attributes: ['#[cfg_attr(kani, kani::proof, kani::unwind(1))]'],
 		args: {
 			proof: true,
 			test: true,
+			stub: false,
 		},
 	},
 	{
-		name: 'function_abc',
+		harnessName: 'function_abc',
 		fullLine: 'fn function_abc() {',
 		endPosition: {
-			row: 28,
+			row: 25,
 			column: 15,
 		},
 		attributes: ['#[kani::unwind(0)]'],
 		args: {
 			proof: true,
 			test: false,
+			stub: false,
 		},
 	},
 	{
-		name: 'function_xyz',
+		harnessName: 'function_xyz',
 		fullLine: 'pub fn function_xyz() {',
 		endPosition: {
-			row: 35,
+			row: 32,
 			column: 19,
 		},
 		attributes: [],
 		args: {
 			proof: true,
 			test: false,
+			stub: false,
 		},
 	},
 	{
-		name: 'function_xyz_2',
+		harnessName: 'function_xyz_2',
 		fullLine: 'unsafe fn function_xyz_2() {',
 		endPosition: {
-			row: 44,
+			row: 41,
 			column: 24,
 		},
 		attributes: ['#[kani::unwind(2)]', '#[kani::solver(kissat)]', '#[kani::should_panic]'],
 		args: {
 			proof: true,
 			test: false,
+			stub: false,
 		},
 	},
 	{
-		name: 'function_xyz_3',
+		harnessName: 'function_xyz_3',
 		fullLine: 'pub unsafe fn function_xyz_3() {',
 		endPosition: {
-			row: 50,
+			row: 47,
 			column: 28,
 		},
 		attributes: [],
 		args: {
 			proof: true,
 			test: false,
+			stub: false,
 		},
 	},
 	{
-		name: 'function_xyz_7',
+		harnessName: 'function_xyz_7',
 		fullLine: 'fn function_xyz_7() {',
 		endPosition: {
-			row: 58,
+			row: 55,
 			column: 17,
 		},
 		attributes: ['#[kani::unwind(0)]', '#[kani::solver(kissat)]'],
 		args: {
 			proof: true,
 			test: false,
+			stub: false,
 		},
 	},
 ];
 
 export const attributeMetadataUnsupported = [
 	{
-		name: 'function_1',
+		harnessName: 'function_1',
 		fullLine: 'fn function_1() {',
 		endPosition: {
 			row: 6,
 			column: 13,
 		},
-		attributes: ['#[kani::unwind(0)]', '#[kani::should_panic]', '#[kani::cover]'],
+		attributes: ["#[kani::unwind(0)]', '#[kani::should_panic]', '#[kani::cover]"],
 		args: {
 			proof: true,
 			test: false,
+			stub: false,
 		},
 	},
 	{
-		name: 'function_2',
-		fullLine: 'pub fn function_2() {',
+		harnessName: 'encrypt_then_decrypt_is_identity',
+		fullLine: 'fn encrypt_then_decrypt_is_identity() {',
 		endPosition: {
-			row: 14,
-			column: 17,
+			row: 18,
+			column: 35,
 		},
-		attributes: ['#[kani::stub]'],
+		attributes: ['#[kani::stub(rand::random, mock_random)]'],
 		args: {
 			proof: true,
 			test: false,
+			stub: true,
+		},
+	},
+	{
+		harnessName: 'function_2',
+		fullLine: 'fn function_2() {',
+		endPosition: {
+			row: 32,
+			column: 13,
+		},
+		attributes: [
+			'#[kani::stub(rand::random, mock_random)]',
+			'#[kani::unwind(2)]',
+			'#[kani::solver(kissat)]',
+			'#[kani::should_panic]',
+		],
+		args: {
+			proof: true,
+			test: false,
+			stub: true,
+		},
+	},
+	{
+		harnessName: 'function_3',
+		fullLine: 'fn function_3() {',
+		endPosition: {
+			row: 38,
+			column: 13,
+		},
+		attributes: [
+			'#[cfg_attr(kani, kani::proof, kani::unwind(1), kani::stub(rand::random, mock_random), kani::solver(kissat))]',
+		],
+		args: {
+			proof: true,
+			test: true,
+			stub: true,
 		},
 	},
 ];

--- a/src/ui/sourceCodeParser.ts
+++ b/src/ui/sourceCodeParser.ts
@@ -195,7 +195,6 @@ export namespace SourceCodeParser {
 	): Promise<void> => {
 		// Create harness metadata for the entire file
 		const allHarnesses: HarnessMetadata[] = await getAttributeFromRustFile(text);
-		// console.log(JSON.stringify(allHarnesses, undefined, 2));
 		const lines = text.split('\n');
 		if (allHarnesses.length > 0) {
 			for (let lineNo = 0; lineNo < lines.length; lineNo++) {

--- a/src/ui/sourceCodeParser.ts
+++ b/src/ui/sourceCodeParser.ts
@@ -85,7 +85,7 @@ export namespace SourceCodeParser {
 						if (strList[j].text != '#[kani::proof]') {
 							attributes.push(strList[j]);
 							attributesMetadata.push(strList[j].text);
-							if(strList[j].text.includes("stub")) {
+							if (strList[j].text.includes('stub')) {
 								stub_bool = true;
 							}
 						}

--- a/src/ui/sourceMap.ts
+++ b/src/ui/sourceMap.ts
@@ -25,8 +25,10 @@ export interface HarnessMetadata {
 export interface AttributeMetaData {
 	/// Whether the harness has been annotated with proof.
 	proof: boolean;
-	/// Whethere the harness has been annotated with test (bolero cases)
+	/// Whether the harness has been annotated with test (bolero cases)
 	test: boolean;
+	/// Stubbing metadata boolean
+	stub: boolean;
 }
 
 interface Position {


### PR DESCRIPTION
### Description of changes: 

The unwind parsing and processing parts were being unused as `kani` detects the values on it's own. Meanwhile, stubbing requires extra arguments provided to `kani`, `--enable-unstable` and `--enable-stubbing`. These changes are necessary to fix #85  .

### Resolved issues:

Resolves #85 

### Testing:

* How is this change tested? Unit test and manual testing

* Is this a refactor change? Yes

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
