### PR TITLE
Open channel after creating one

### DIFF
--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -219,6 +219,8 @@ function sendErrorToChannel(output: CommandOutput, args: string[]): void {
 
 	// Append stdout to the output channel
 	channel.appendLine(output.error?.message);
+	// Open channel but don't change focus
+	channel.show(true);
 }
 
 // Creates a unique name and adds a channel for the harness output to Output Logs
@@ -231,4 +233,6 @@ function sendOutputToChannel(output: CommandOutput, args: string[]): void {
 
 	// Append stdout to the output channel
 	channel.appendLine(output.stdout);
+	// Open channel but don't change focus
+	channel.show(true);
 }


### PR DESCRIPTION
### Description of changes: 

After running Kani, open the output channel without changing focus so it's clear for the user to see what has happened.

### Resolved issues:

N/A

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

We could potentially only open when there was a problem, but I personally thing it's very helpful to see the output without having to go through all the other channels that were previously created by Kani.

### Testing:

* How is this change tested? Manual

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
