### PR TITLE
Fix concrete playback with bolero

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -176,7 +176,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	const runningConcretePlayback = vscode.commands.registerCommand(
 		'Kani.runConcretePlayback',
 		async (harnessArgs) => {
-			callConcretePlayback('Kani.runConcretePlayback', harnessArgs);
+			callConcretePlayback(harnessArgs);
 		},
 	);
 

--- a/src/test-tree/createTests.ts
+++ b/src/test-tree/createTests.ts
@@ -425,7 +425,7 @@ class FailedCase extends TestCase {
 			`command:Kani.runConcretePlayback?${encodeURIComponent(JSON.stringify(args))}`,
 		);
 		sample.appendMarkdown(
-			`[Run concrete playback for ${this.harness_name}](${concretePlaybackUri})`,
+			`[Generate concrete test for ${this.harness_name}](${concretePlaybackUri})`,
 		);
 
 		return sample;

--- a/src/ui/concrete-playback/concretePlayback.ts
+++ b/src/ui/concrete-playback/concretePlayback.ts
@@ -13,9 +13,11 @@ import { checkCargoExist, getPackageName, getRootDir } from '../../utils';
  * @param commandURI - vscode command that is being executed
  * @param harnessObj - metadata about the harness
  */
-export async function callConcretePlayback(
-	harnessObj: { harnessName: string; harnessFile: string; harnessType: boolean },
-): Promise<void> {
+export async function callConcretePlayback(harnessObj: {
+	harnessName: string;
+	harnessFile: string;
+	harnessType: boolean;
+}): Promise<void> {
 	let finalCommand: string = '';
 
 	const platform: NodeJS.Platform = process.platform;
@@ -38,14 +40,10 @@ export async function callConcretePlayback(
 }
 
 // Check if cargo toml exists and create corresponding kani command
-function createCommand(
-	packageName: string,
-	harnessName: string,
-	harnessType: boolean,
-): string {
+function createCommand(packageName: string, harnessName: string, harnessType: boolean): string {
 	// Check if cargo toml exists
 	const isCargo = checkCargoExist();
-	const kaniArgs = `${KaniArguments.harnessFlag} ${harnessName} -p ${packageName} -Z concrete-playback --concrete-playback=inplace`
+	const kaniArgs = `${KaniArguments.harnessFlag} ${harnessName} -p ${packageName} -Z concrete-playback --concrete-playback=inplace`;
 
 	if (harnessType) {
 		return `${KaniConstants.CargoKaniExecutableName} ${kaniArgs}`;


### PR DESCRIPTION
### Description of changes: 

Remove incorrect and no longer needed option to use standalone Kani when tests is enabled.

### Resolved issues:

Resolves #66 

### Related RFC:

N/A

### Call-outs:

1. I renamed the button to generate concrete tests. When I read "run", I expect the test to be executed, which is not the case.
2. It's my understanding that we only work with Cargo for the extension, so I removed the standalone Kani logic. Let me know if I'm wrong.

### Testing:

* How is this change tested? Manual tests

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
