### PR TITLE
Replace `cargo test` by `cargo kani playback`

### DIFF
--- a/src/debugger/debugger.ts
+++ b/src/debugger/debugger.ts
@@ -20,8 +20,8 @@ async function getBinaryPath(): Promise<string | undefined> {
 		};
 
 		// <https://github.com/model-checking/kani-vscode-extension/issues/68#issue-1706506359>
-		const cargoTestCommand: string = `RUSTFLAGS="--cfg=kani" cargo +nightly test --no-run --message-format=json`;
-		const output = execSync(`cd ${directory} && ${cargoTestCommand}`);
+		const playbackCommand: string = `cargo kani playback -Z concrete-playback --only-codegen --message-format=json`;
+		const output = execSync(`cd ${directory} && ${playbackCommand}`);
 
 		const outputString = output.toString();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,8 +4,8 @@ import * as vscode from 'vscode';
 import { Uri } from 'vscode';
 
 import { connectToDebugger } from './debugger/debugger';
+import { runKaniPlayback } from './model/kaniPlayback';
 import { getKaniPath } from './model/kaniRunner';
-import { runCargoTest } from './model/runCargoTest';
 import { gatherTestItems } from './test-tree/buildTree';
 import {
 	KaniData,
@@ -220,7 +220,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 	// Register the command for the code lens Kani test runner function
 	vscode.commands.registerCommand('codelens-sample.codelensAction', (args: any) => {
-		runCargoTest(args);
+		runKaniPlayback(args);
 	});
 
 	// Update the test tree with proofs whenever a test case is opened

--- a/src/model/kaniPlayback.ts
+++ b/src/model/kaniPlayback.ts
@@ -8,8 +8,8 @@ import { getPackageName, getRootDir } from '../utils';
  * Runs the cargo test task whenever the user clicks on a codelens button
  * @param functionName - Name of the unit test being run by the user
  */
-export async function runCargoTest(functionName: string): Promise<void> {
-	const taskName = `Cargo Test: ${functionName}`;
+export async function runKaniPlayback(functionName: string): Promise<void> {
+	const taskName = `Kani Playback: ${functionName}`;
 
 	const packageName = await getPackageName(getRootDir());
 	const taskDefinition: vscode.TaskDefinition = {
@@ -18,15 +18,13 @@ export async function runCargoTest(functionName: string): Promise<void> {
 		args: [functionName],
 	};
 
-	// Adding `--bin {packageName}` to the command prevents recompiling when
-	// there's no changes to the unit tests, which makes rerunning unit tests faster.
-	const cargoTestCommand: string = `RUSTFLAGS="--cfg=kani" cargo test --package ${packageName} --bin ${packageName} -- ${functionName} --nocapture`;
+	const playbackCommand: string = `cargo kani playback --package ${packageName} -Z concrete-playback -- ${functionName} --nocapture`;
 	const task = new vscode.Task(
 		taskDefinition,
 		vscode.TaskScope.Workspace,
 		taskName,
 		'cargo',
-		new vscode.ShellExecution(cargoTestCommand),
+		new vscode.ShellExecution(playbackCommand),
 	);
 	vscode.tasks.executeTask(task);
 }


### PR DESCRIPTION
### Description of changes: 

Use the new playback subcommand so users don't have to manually add Kani library to their Cargo.toml, and to ensure that they don't need nightly cargo toolchain.

With this change, user's don't need to modify their Cargo.toml in order to execute concrete playback tests.

### Resolved issues:

Resolves #74 

### Related RFC:


### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Manually

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
