### PR TITLE
Add Dev Kani detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kani-vscode-extension",
-  "version": "0.0.3",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kani-vscode-extension",
-      "version": "0.0.3",
+      "version": "0.0.2",
       "dependencies": {
         "esbuild": "0.16.2",
         "readline": "^1.3.0",
@@ -32,7 +32,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-tsdoc": "^0.2.17",
-        "glob": "^8.0.3",
+        "glob": "^8.1.0",
         "mocha": "^10.0.0",
         "prettier": "2.8.0",
         "typescript": "^4.7.4"
@@ -1934,9 +1934,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-tsdoc": "^0.2.17",
-    "glob": "^8.0.3",
+    "glob": "^8.1.0",
     "mocha": "^10.0.0",
     "prettier": "2.8.0",
     "typescript": "^4.7.4"

--- a/src/debugger/debugger.ts
+++ b/src/debugger/debugger.ts
@@ -5,8 +5,8 @@ import path from 'path';
 
 import * as vscode from 'vscode';
 
-import { getPackageName, getRootDir, getRootDirURI } from '../utils';
 import { getBinaryAbsolutePath } from '../model/kaniRunner';
+import { getPackageName, getRootDir, getRootDirURI } from '../utils';
 
 // Extracts the path for the cargo artifact for the user's crate which we shall plug into the debugger
 // by connecting to the vscode debugger controller

--- a/src/debugger/debugger.ts
+++ b/src/debugger/debugger.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import * as vscode from 'vscode';
 
 import { getPackageName, getRootDir, getRootDirURI } from '../utils';
+import { getBinaryAbsolutePath } from '../model/kaniRunner';
 
 // Extracts the path for the cargo artifact for the user's crate which we shall plug into the debugger
 // by connecting to the vscode debugger controller
@@ -20,7 +21,8 @@ async function getBinaryPath(): Promise<string | undefined> {
 		};
 
 		// <https://github.com/model-checking/kani-vscode-extension/issues/68#issue-1706506359>
-		const playbackCommand: string = `cargo kani playback -Z concrete-playback --only-codegen --message-format=json`;
+		const pathKani = await getBinaryAbsolutePath('cargo-kani');
+		const playbackCommand: string = `${pathKani} playback -Z concrete-playback --only-codegen --message-format=json`;
 		const output = execSync(`cd ${directory} && ${playbackCommand}`);
 
 		const outputString = output.toString();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import { Uri } from 'vscode';
 
 import { connectToDebugger } from './debugger/debugger';
 import { runKaniPlayback } from './model/kaniPlayback';
-import { getKaniPath } from './model/kaniRunner';
+import { getBinaryAbsolutePath, getKaniVersion } from './model/kaniRunner';
 import { gatherTestItems } from './test-tree/buildTree';
 import {
 	KaniData,
@@ -37,7 +37,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	}
 	try {
 		// GET binary path
-		const kaniBinaryPath = await getKaniPath('cargo-kani');
+		const kaniBinaryPath = await getBinaryAbsolutePath('cargo-kani');
+		await getKaniVersion();
 	} catch (error) {
 		showErrorWithReportIssueButton(
 			'The Kani executable was not found in PATH. Please install it using the instructions at https://model-checking.github.io/kani/install-guide.html and/or make sure it is in your PATH.',

--- a/src/model/kaniPlayback.ts
+++ b/src/model/kaniPlayback.ts
@@ -3,6 +3,7 @@
 import * as vscode from 'vscode';
 
 import { getPackageName, getRootDir } from '../utils';
+import { getBinaryAbsolutePath } from './kaniRunner';
 
 /**
  * Runs the cargo test task whenever the user clicks on a codelens button
@@ -18,7 +19,9 @@ export async function runKaniPlayback(functionName: string): Promise<void> {
 		args: [functionName],
 	};
 
-	const playbackCommand: string = `cargo kani playback --package ${packageName} -Z concrete-playback -- ${functionName} --nocapture`;
+	const kaniCommand = await getBinaryAbsolutePath('cargo-kani');
+
+	const playbackCommand: string = `${kaniCommand} playback --package ${packageName} -Z concrete-playback -- ${functionName}`;
 	const task = new vscode.Task(
 		taskDefinition,
 		vscode.TaskScope.Workspace,

--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -3,7 +3,9 @@
 import { execFile } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import { promisify } from 'util';
 
+import glob from 'glob';
 import * as vscode from 'vscode';
 
 import { KaniResponse } from '../constants';
@@ -15,8 +17,6 @@ import {
 	splitCommand,
 } from '../utils';
 import { checkOutputForError, responseParserInterface } from './kaniOutputParser';
-import { promisify } from 'util';
-import glob from 'glob';
 
 const globAsync = promisify(glob);
 
@@ -36,23 +36,23 @@ interface CommandOutput {
  */
 export async function getBinaryAbsolutePath(binaryName: string): Promise<string> {
 	try {
-	  // Try using 'which' command
-	  const output = await getKaniPath(binaryName);
-	  if (output) {
-		return output.trim();
-	  }
+		// Try using 'which' command
+		const output = await getKaniPath(binaryName);
+		if (output) {
+			return output.trim();
+		}
 	} catch (error) {
-	  // Ignore 'which' command error
+		// Ignore 'which' command error
 	}
 
 	try {
-	  // Try using glob pattern to find the binary
-	  const matches = await globAsync(`kani/scripts/cargo-kani`, { absolute: true });
-	  if (matches.length > 0) {
-		return matches[0];
-	  }
+		// Try using glob pattern to find the binary
+		const matches = await globAsync(`kani/scripts/cargo-kani`, { absolute: true });
+		if (matches.length > 0) {
+			return matches[0];
+		}
 	} catch (error) {
-	  // Ignore glob error
+		// Ignore glob error
 	}
 
 	// Throw an error if both 'which' and glob failed
@@ -67,8 +67,8 @@ export async function getKaniVersion(): Promise<void> {
 
 		execFile(pathKani, ['--version'], (error, stdout, stderr) => {
 			if (error) {
-			  console.error(`Error: ${error}`);
-			  return;
+				console.error(`Error: ${error}`);
+				return;
 			}
 
 			if (stdout) {
@@ -84,12 +84,12 @@ export async function getKaniVersion(): Promise<void> {
 
 			console.log(`stdout: ${stdout}`);
 			console.error(`stderr: ${stderr}`);
-		  });
-	  } catch (error) {
+		});
+	} catch (error) {
 		// Ignore command error
 		return;
-	  }
-	  return;
+	}
+	return;
 }
 
 /**

--- a/src/model/kaniRunner.ts
+++ b/src/model/kaniRunner.ts
@@ -63,7 +63,6 @@ export async function getBinaryAbsolutePath(binaryName: string): Promise<string>
 export async function getKaniVersion(): Promise<void> {
 	try {
 		const pathKani = await getBinaryAbsolutePath('cargo-kani');
-		console.log(pathKani);
 
 		execFile(pathKani, ['--version'], (error, stdout, stderr) => {
 			if (error) {
@@ -152,7 +151,6 @@ export async function runKaniCommand(
 
 	if (command == 'cargo' || command == 'cargo kani') {
 		const kaniBinaryPath = await getBinaryAbsolutePath('cargo-kani');
-		console.log(`The path to kani is - ${kaniBinaryPath}`);
 		const options = {
 			shell: false,
 			cwd: directory,
@@ -192,7 +190,6 @@ export async function createFailedDiffMessage(command: string): Promise<KaniResp
 	// Check the command running and execute that with the full path and safe options
 	if (commandSplit.commandPath == 'cargo' || commandSplit.commandPath == 'cargo kani') {
 		const kaniBinaryPath = await getBinaryAbsolutePath('cargo-kani');
-		console.log(`The path to kani for executing is - ${kaniBinaryPath}`);
 		const options = {
 			shell: false,
 			cwd: directory,


### PR DESCRIPTION
### Description of changes: 

This change allows development version of `kani` to be picked up automatically and run by default, even if it is not added to PATH. This is particularly useful for end-to-end testing.

Also changes a few command invocations to use the full path to the kani binary instead of relying on the shell to disambiguate from the PATH.

### Resolved issues:

Resolves #34 

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
