### PR TITLE
Store and use single file kani path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,7 +45,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		const KaniPath = await getKaniPath('kani');
 		globalConfig.setFilePath(CargoKaniBinaryPath);
 		globalConfig.setKanifilePath(KaniPath);
-
 	} catch (error) {
 		showErrorWithReportIssueButton(
 			'The Kani executable was not found in PATH. Please install it using the instructions at https://model-checking.github.io/kani/install-guide.html and/or make sure it is in your PATH.',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,15 +41,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	try {
 		// GET binary path
 		const globalConfig = GlobalConfig.getInstance();
-		const kaniBinaryPath = await getKaniPath('cargo-kani');
-		globalConfig.setFilePath(kaniBinaryPath);
+		const CargoKaniBinaryPath = await getKaniPath('cargo-kani');
+		const KaniPath = await getKaniPath('kani');
+		globalConfig.setFilePath(CargoKaniBinaryPath);
+		globalConfig.setKanifilePath(KaniPath);
 
-		vscode.window.showInformationMessage(
-			`Kani located at ${kaniBinaryPath} being used for verification`,
-		);
-
-		// GET Version number and display to user
-		await getKaniVersion(globalConfig.getFilePath());
 	} catch (error) {
 		showErrorWithReportIssueButton(
 			'The Kani executable was not found in PATH. Please install it using the instructions at https://model-checking.github.io/kani/install-guide.html and/or make sure it is in your PATH.',

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -1,11 +1,13 @@
 // Copyright Kani Contributors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 class GlobalConfig {
-	private static instance: GlobalConfig;
-	private filePath: string;
+	public static instance: GlobalConfig;
+	public filePath: string;
+	public KanifilePath = '';
 
 	private constructor() {
 		this.filePath = '';
+		this.KanifilePath = '';
 	}
 
 	public static getInstance(): GlobalConfig {
@@ -22,6 +24,15 @@ class GlobalConfig {
 	public getFilePath(): string {
 		return this.filePath;
 	}
+
+	public setKanifilePath(filePath: string): void {
+		this.KanifilePath = filePath;
+	}
+
+	public getKanifilePath() {
+		return this.KanifilePath;
+	}
+
 }
 
 export default GlobalConfig;

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -32,7 +32,6 @@ class GlobalConfig {
 	public getKanifilePath() {
 		return this.KanifilePath;
 	}
-
 }
 
 export default GlobalConfig;


### PR DESCRIPTION
### Description of changes: 

1. Add single file Kani path to global config, will be useful for some features that are file exclusive (like coverage).
2. Remove popup for kani's path on startup

### Resolved issues:

Resolves #120 

### Testing:

* How is this change tested? Manual

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
