### PR TITLE
Fix output parsing when using debugger

### DIFF
--- a/src/debugger/debugger.ts
+++ b/src/debugger/debugger.ts
@@ -46,7 +46,7 @@ async function getBinaryPath(): Promise<string | undefined> {
 		const outputString = output.toString();
 		const lines = outputString.trim().split('\n');
 		// Remove version string before json parsing
-		// This is a temporary patch till https://github.com/model-checking/kani/issues/2649 is fixed.
+		// NOTE: This is a temporary patch till <https://github.com/model-checking/kani/issues/2649> is fixed.
 		lines.shift();
 
 		// Parse json objects from response

--- a/src/debugger/debugger.ts
+++ b/src/debugger/debugger.ts
@@ -44,8 +44,11 @@ async function getBinaryPath(): Promise<string | undefined> {
 
 		const output = execFileSync(kaniBinaryPath, commandSplit.args, options);
 		const outputString = output.toString();
-
 		const lines = outputString.trim().split('\n');
+		// Remove version string before json parsing
+		lines.shift();
+
+		// Parse json objects from response
 		const jsonMessages = lines.map((line: string) => JSON.parse(line));
 
 		/*

--- a/src/debugger/debugger.ts
+++ b/src/debugger/debugger.ts
@@ -45,11 +45,11 @@ async function getBinaryPath(): Promise<string | undefined> {
 		const output = execFileSync(kaniBinaryPath, commandSplit.args, options);
 		const outputString = output.toString();
 		const lines = outputString.trim().split('\n');
-		// Remove version string before json parsing
+		// Remove version string before JSON parsing
 		// NOTE: This is a temporary patch till <https://github.com/model-checking/kani/issues/2649> is fixed.
 		lines.shift();
 
-		// Parse json objects from response
+		// Parse JSON objects from response
 		const jsonMessages = lines.map((line: string) => JSON.parse(line));
 
 		/*

--- a/src/debugger/debugger.ts
+++ b/src/debugger/debugger.ts
@@ -46,6 +46,7 @@ async function getBinaryPath(): Promise<string | undefined> {
 		const outputString = output.toString();
 		const lines = outputString.trim().split('\n');
 		// Remove version string before json parsing
+		// This is a temporary patch till https://github.com/model-checking/kani/issues/2649 is fixed.
 		lines.shift();
 
 		// Parse json objects from response


### PR DESCRIPTION
### Description of changes: 

The first object returned is now a non-JSON version string line from `Kani`. This is a result of the change from https://github.com/model-checking/kani/pull/2619.

This PR adds a fix to the output parsing when parsing the JSON objects in debugger mode.

### Call-outs:

1. This is a temporary patch while https://github.com/model-checking/kani/issues/2649 is fixed from Kani's side.

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
