### PR TITLE
Add error messaging to user when Kani crashes during coverage

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Check TS linting
         run: |
-          npm install -g npm@latest
+          npm install -g npm@9.8
           npm install
           npm run lint
 

--- a/src/ui/coverage/coverageInfo.ts
+++ b/src/ui/coverage/coverageInfo.ts
@@ -84,7 +84,13 @@ async function runCoverageCommand(command: string, harnessName: string): Promise
 
 	vscode.window.showInformationMessage(`Generating coverage for ${harnessName}`);
 	return new Promise((resolve, _reject) => {
-		execFile(kaniBinaryPath, args, options, async (_error: any, stdout: any, _stderr: any) => {
+		execFile(kaniBinaryPath, args, options, async (error: any, stdout: any, stderr: any) => {
+
+			// Check for compilation errors from Kani
+			if(stderr && stderr.includes('error: could not compile')) {
+				vscode.window.showInformationMessage(`Kani had errors during compilation to following errors: \n${stdout}`);
+			}
+
 			if (stdout) {
 				const parseResult = await parseKaniCoverageOutput(stdout);
 				resolve({ statusCode: 0, result: parseResult });


### PR DESCRIPTION
### Description of changes: 

Adds error messaging to the user when there in an underlying crash from Kani during coverage highlighting.

### Resolved issues:

Resolves #126 

### Testing:

* How is this change tested? Manually

* Is this a refactor change? No

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
