### PR TITLE
Replace deprecated `--enable-stubbing`

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,5 +17,5 @@ export namespace KaniArguments {
 	export const testsFlag: string = `--tests`;
 	export const outputFormatFlag: string = `--output-format`;
 	export const unstableFormatFlag: string = `--enable-unstable`;
-	export const stubbingFlag: string = `--enable-stubbing`;
+	export const stubbingFlag: string = `-Z=stubbing`;
 }

--- a/src/model/kaniCommandCreate.ts
+++ b/src/model/kaniCommandCreate.ts
@@ -77,13 +77,13 @@ function createCommand(
 		if (stubbing_args === undefined || !stubbing_args) {
 			harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.harnessFlag} ${harnessName}`;
 		} else {
-			harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.unstableFormatFlag} ${KaniArguments.stubbingFlag} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.harnessFlag} ${harnessName}`;
+			harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.stubbingFlag} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.harnessFlag} ${harnessName}`;
 		}
 	} else {
 		if (stubbing_args === undefined || !stubbing_args) {
 			harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.packageFlag} ${packageName}  ${KaniArguments.harnessFlag} ${harnessName}`;
 		} else {
-			harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.unstableFormatFlag} ${KaniArguments.stubbingFlag} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.harnessFlag} ${harnessName}`;
+			harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.stubbingFlag} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.harnessFlag} ${harnessName}`;
 		}
 	}
 

--- a/src/model/kaniCommandCreate.ts
+++ b/src/model/kaniCommandCreate.ts
@@ -72,19 +72,13 @@ function createCommand(
 	testFlag: boolean = false,
 	stubbing_args?: boolean,
 ): string {
-	let harnessCommand = '';
-	if (!testFlag) {
-		if (stubbing_args === undefined || !stubbing_args) {
-			harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.harnessFlag} ${harnessName}`;
-		} else {
-			harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.stubbingFlag} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.harnessFlag} ${harnessName}`;
-		}
-	} else {
-		if (stubbing_args === undefined || !stubbing_args) {
-			harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.packageFlag} ${packageName}  ${KaniArguments.harnessFlag} ${harnessName}`;
-		} else {
-			harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.testsFlag} ${KaniArguments.stubbingFlag} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.harnessFlag} ${harnessName}`;
-		}
+	let harnessCommand = `${KaniConstants.CargoKaniExecutableName} ${KaniArguments.packageFlag} ${packageName} ${KaniArguments.harnessFlag} ${harnessName}`;
+	if (testFlag) {
+		harnessCommand = `${harnessCommand} ${KaniArguments.testsFlag}`;
+	}
+
+	if (stubbing_args !== undefined && stubbing_args) {
+		harnessCommand = `${harnessCommand} ${KaniArguments.stubbingFlag}`;
 	}
 
 	return harnessCommand;


### PR DESCRIPTION
### Description of changes: 

When stubbing is enabled, replace `--enable-unstable --enable-stubbing` by `-Z=stubbing`.

### Resolved issues:

N/A

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
