### PR TITLE
Remove redundant `npm install` step

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -20,7 +20,6 @@ jobs:
 
       - name: Check TS linting
         run: |
-          npm install -g npm@latest
           npm install
           npm run lint
 


### PR DESCRIPTION
### Description of changes: 

Remove `npm install latest` as it is redundant, given the install step mentioned above it.