### PR TITLE
Restrict workflow permissions to read-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 name: Run Unit Tests
 on: pull_request
-
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 # Copyright Kani Contributors
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 name: Deploy Extension
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 name: Format Check
 on: pull_request
+permissions:
+  contents: read
 
 jobs:
   format-check:


### PR DESCRIPTION
### Description of changes: 

Per CodeQL recommendation restrict permissions to read-only rather than the default of read-write.

### Resolved issues:

Addresses security recommendations at https://github.com/model-checking/kani-vscode-extension/security/code-scanning.

### Testing:

* How is this change tested? CI runs

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- n/a Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
