### PR TITLE
Ignore TypeScript 7.x major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # TypeScript 7.x is the native ("Corsa"/Go) rewrite and does not expose
+      # the classic JS compiler API (e.g. `ts.Extension`). Our lint toolchain
+      # depends on that API via @typescript-eslint, whose peer requirement is
+      # still `typescript <6.1.0`, so bumping to 7.x breaks `npm run lint`
+      # (see #352). Ignore the major bump until @typescript-eslint supports it.
+      - dependency-name: "typescript"
+        versions: [">=7.0.0"]


### PR DESCRIPTION
## Summary

Tells dependabot to stop proposing TypeScript **7.x** upgrades until our lint toolchain supports it.

## Why

Dependabot #352 tried to bump `typescript` `6.0.3 → 7.0.2`, which fails CI in both `format-check` and `build`:

```
Oops! Something went wrong! :(
ESLint: 10.8.1
TypeError: Cannot read properties of undefined (reading 'Cjs')
    at .../@typescript-eslint/typescript-estree/dist/create-program/shared.js:59:18
```

TypeScript 7.x is the **native ("Corsa"/Go) rewrite**. Its npm package has an entirely different structure and no longer exposes the classic JS compiler API (`ts.Extension`, `ts.ModuleKind`, …). `tsc` still compiles, but anything doing `import * as ts from 'typescript'` breaks — hence `ts.Extension` is `undefined`.

Our `npm run lint` uses `@typescript-eslint`, and **no released or pre-release version supports TS 7**: the latest (8.68.0) and canary builds all pin peer `typescript: ">=4.8.4 <6.1.0"`. There is nothing to bump the linter to, so the bump cannot pass CI.

## Change

Adds a dependabot `ignore` entry for `typescript >=7.0.0`. `package.json` already constrains `typescript` to `^6.0.3` (`<7.0.0`), so no source change is needed; this just keeps dependabot from re-proposing the same broken major bump.

Closes #352 (that PR is being closed as not-mergeable).